### PR TITLE
Fix BED file sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ Complete list of open issues is available on [Github-Issues](https://github.com/
 Please report any new issues ad [new Github-Issue](https://github.com/microPIECE-team/microPIECE/issues/new).
 
 ## Changelog
+Version v1.0.2 (2018-03-05) Fixes the incorrect sorting of BED files, result was correct, but sorting was performed in the wrong order. (Fixes #63)
+
 Version v1.0.1 (2018-03-05) Fix an error conserning BED file handling of start and stop coordinates. (Fixes #59)
 
 Version 1.0.0 (2018-03-05) is archived as [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1188484.svg)](https://doi.org/10.5281/zenodo.1188484) and submitted to [The Journal of Open Source Software](http://joss.theoj.org/).

--- a/lib/microPIECE.pm
+++ b/lib/microPIECE.pm
@@ -3,7 +3,7 @@ package microPIECE;
 use strict;
 use warnings;
 
-use version 0.77; our $VERSION = version->declare("v1.0.1");
+use version 0.77; our $VERSION = version->declare("v1.0.2");
 
 use Log::Log4perl;
 use Data::Dumper;

--- a/lib/microPIECE.pm
+++ b/lib/microPIECE.pm
@@ -1004,7 +1004,7 @@ sub run_CLIP_process
 	    push(@dat, \@fields);
 	}
 
-	@dat = sort { $a->[0] cmp $b->[0] || $a->[1] <=> $b->[2] } (@dat);
+	@dat = sort { $a->[0] cmp $b->[0] || $a->[1] <=> $b->[1] } (@dat);
 
 	open(FH, ">", $sorted_bed) || $L->logdie("Unable to open '$sorted_bed': $!");
 	foreach my $fields (@dat)

--- a/microPIECE.pl
+++ b/microPIECE.pl
@@ -275,6 +275,10 @@ Please report any new issues ad L<new Github-Issue|https://github.com/microPIECE
 
 =over 4
 
+=item v1.0.2 (2018-03-05)
+
+Fixes the incorrect sorting of BED files, result was correct, but sorting was performed in the wrong order. (Fixes #63)
+
 =item v1.0.1 (2018-03-05)
 
 Fix an error conserning BED file handling of start and stop coordinates. (Fixes #59)


### PR DESCRIPTION
Fix #63 

The final sorting was correct, but the sorting algorithm was wrong. It is corrected now according to the required procedure from http://bedtools.readthedocs.io/en/latest/content/tools/merge.html