### PR TITLE
removed 's' from parameter --mirna in help

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ Complete list of open issues is available on [Github-Issues](https://github.com/
 Please report any new issues ad [new Github-Issue](https://github.com/microPIECE-team/microPIECE/issues/new).
 
 ## Changelog
+Version v1.0.5 (2018-03-06) Update of documentation and correct spelling of `--mirna` parameter
+
 Version v1.0.4 (2018-03-06) Fixes complete mature in final output (Fixes #69)
 
 Version v1.0.3 (2018-03-06) Add tests for perl scripts in script folder which ensure the correct handling of BED stop coordinates (Fixes #65)

--- a/lib/microPIECE.pm
+++ b/lib/microPIECE.pm
@@ -3,7 +3,7 @@ package microPIECE;
 use strict;
 use warnings;
 
-use version 0.77; our $VERSION = version->declare("v1.0.4");
+use version 0.77; our $VERSION = version->declare("v1.0.5");
 
 use Log::Log4perl;
 use Data::Dumper;

--- a/microPIECE.pl
+++ b/microPIECE.pl
@@ -121,7 +121,7 @@ microPIECE - microRNA pipeline enhanced by CLIP experiments
    --annotationA <speciesA_genome.gff> \
    --annotationB <speciesB_genome.gff> \
    --clip <ago_clip_seq.fastq> \
-   --mirnas <mature_miRNAs.fa>
+   --mirna <mature_miRNAs.fa>
 
 =head1 DESCRIPTION
 
@@ -224,7 +224,7 @@ piranha). This option should not be used in real analysis!
 
 output folder
 
-=item C<--mirnas>
+=item C<--mirna>
 
 miRNA set, if set, mining is disabled and this set is used for prediction
 

--- a/microPIECE.pl
+++ b/microPIECE.pl
@@ -275,6 +275,10 @@ Please report any new issues ad L<new Github-Issue|https://github.com/microPIECE
 
 =over 4
 
+=item v1.0.5 (2018-03-06)
+
+Update of documentation and correct spelling of C<--mirna> parameter
+
 =item v1.0.4 (2018-03-06)
 
 Fixes complete mature in final output (Fixes #69)


### PR DESCRIPTION
the help message was deprecated concerning the `--mirna` parameter