### PR TITLE
Add support for a --mirbasedir parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ docker run -it --rm -v $PWD:/data micropiece/micropiece microPIECE.pl   \
     Three letter code of species where we want to predict the miRNA
     targets (species B, `--speciesBtag`).
 
+- `--mirbasedir`
+
+    The folder specified by `--mirbasedir` is searched for the files
+    `organisms.txt.gz`, `mature.fa.gz`, and `hairpin.fa.gz`. If the
+    files are not exist, they will be downloaded.
+
 
 ### OUTPUT
 - mature miRNA set: `mature_combined_mirbase_novel.fa`

--- a/lib/microPIECE.pm
+++ b/lib/microPIECE.pm
@@ -756,8 +756,13 @@ sub run_mining_downloads
     foreach my $key(sort keys %filelist)
     {
 	my $file = $filelist{$key};
-	my @cmd=("wget", "--quiet", "ftp://mirbase.org/pub/mirbase/CURRENT/".$file);
-	run_cmd($L, \@cmd);
+	unless (exists $opt->{mirbasedir} && defined $opt->{mirbasedir} && -e $opt->{mirbasedir}."/".$file)
+	{
+	    my @cmd=("wget", "--quiet", "ftp://mirbase.org/pub/mirbase/CURRENT/".$file);
+	    run_cmd($L, \@cmd);
+	} else {
+	    $file = $opt->{mirbasedir}."/".$file;
+	}
 	# decompress the file
 	my $output = basename($file, ".gz");
 	my $status = gunzip $file => $output || $L->logdie("gunzip failed: $GunzipError");

--- a/microPIECE.pl
+++ b/microPIECE.pl
@@ -47,6 +47,7 @@ my $opt = {
     testrun            => undef,
     mirna              => undef,
     speciesB_tag       => undef,
+    mirbasedir         => undef,
 };
 
 GetOptions(
@@ -68,7 +69,8 @@ GetOptions(
     'testrun'              => \$opt->{testrun},
     'out=s'                => \$opt->{out},
     'mirna=s'              => \$opt->{mirna},
-    'speciesBtag=s'           => \$opt->{speciesB_tag},
+    'speciesBtag=s'        => \$opt->{speciesB_tag},
+    'mirbasedir=s'         => \$opt->{mirbasedir},
     ) || pod2usage(1);
 
 # split clip files if required
@@ -232,6 +234,12 @@ miRNA set, if set, mining is disabled and this set is used for prediction
 
 Three letter code of species where we want to predict the miRNA
 targets (species B, C<--speciesBtag>).
+
+=item C<--mirbasedir>
+
+The folder specified by C<--mirbasedir> is searched for the files
+F<organisms.txt.gz>, F<mature.fa.gz>, and F<hairpin.fa.gz>. If the
+files are not exist, they will be downloaded.
 
 =back
 

--- a/t/run_complete.sh
+++ b/t/run_complete.sh
@@ -13,4 +13,5 @@ perl -MDevel::Cover=-coverage,statement,branch,condition,path,subroutine,time /o
    --adaptersmallrnaseq5 GTTCAGAGTTCTACAGTCCGACGATC \
    --filterncrnas /tmp/microPIECE-testset/TCA_all_ncRNA_but_miR.fa \
    --speciesB tca \
+   --mirbasedir /tmp/microPIECE-testset \
    --out complete


### PR DESCRIPTION
To circumvent download issues with mirbase, the files can now be provided in a local folder. The location to that folder need to be specified via `--mirbasedir` parameter.