### PR TITLE
Adding code of conduct and contribution instruction

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at frank.foerster@ime.fraunhofer.de or daniel.amsel@ime.fraunhofer.de. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Please follow this procedure
 
 When filing an issue, make sure to answer those questions:
 
-1. What version of Perl and chloroExtractor are you using?
+1. What version of Perl and microPIECE are you using?
 2. What operating system are you using?
 3. What did you do?
 4. What did you expect to see?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Introduction
+
+Thank you for considering contributing to the microPIECE software.
+
+Following these guidelines helps the developers of this open source project.
+Making it easier for them to address your issue, assess changes, and help you finalize your pull requests.
+Any kind of contribution, to code, documentation, examples or tests are welcome.
+
+# Ground Rules
+Please have a look at our [code of conduct](CODE_OF_CONDUCT.md).
+
+# Contributing Code
+Please follow this procedure
+1. Open an issue with a bug report or feature request (indicate that you are willing to do the coding yourself)
+2. Create your own fork of the code
+3. Do the changes in your fork
+4. Open a pull request
+
+# How to report a bug
+
+When filing an issue, make sure to answer those questions:
+
+1. What version of Perl and chloroExtractor are you using?
+2. What operating system are you using?
+3. What did you do?
+4. What did you expect to see?
+5. What did you see instead?
+
+# How to suggest a feature or enhancement
+
+Open an issue which describes the feature you would like to see, why you need it, and how it should work.

--- a/issue_template.md
+++ b/issue_template.md
@@ -1,8 +1,16 @@
+# What did you do?
+*Please explain what you did to encounter the problem.*
+
 # Expected behavior
-*Please explain the behavior you would expect*
+*Please explain the behavior you would expect.*
 
 # Actual behavior
-*Please describe the actual behavior*
+*Please describe the actual behavior.*
 
-# Version
-*Please specify the version number(s), eg. v1.1.0 or v1.0.8-v1.1.0*
+# What version of \[Perl and microPIECE | Docker image and Docker\] are you using? 
+*Did you use a local installation ? Then please tell us your Perl and microPIECE version.*
+
+*Did you use a Docker image and Docker? Then please tell us your image and Docker version.*
+
+# What operating system are you using?
+*In any case, please tell us what OS you are using.*


### PR DESCRIPTION
Fixes #89 and #90 .

Changes proposed within this pull request
- adds `CODE_OF_CONDUCT.md`
- adds `CONTRIBUTING.md`

@microPIECE-team/micropiece-team-admins
