### PR TITLE
Implement stabil numbering of new miRNAs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 install:
     - cpanm Devel::Cover Devel::Cover::Report::Coveralls Test::Script::Run Log::Log4perl
 script:
-    - docker run -it --rm -v $PWD:/opt/microPIECE -v /tmp/microPIECE-testset:/tmp/microPIECE-testset micropiece/micropiece /bin/bash -c 'cd /opt/microPIECE; PERL5OPT="-MDevel::Cover=-coverage,statement,branch,condition,path,subroutine,time" prove -It -Ilib/ t/*.t'
+    - docker run -it --rm -v $PWD:/opt/microPIECE -v /tmp/microPIECE-testset:/tmp/microPIECE-testset micropiece/micropiece /bin/bash -c 'cd /opt/microPIECE; PERL5OPT="-MDevel::Cover=-coverage,statement,branch,condition,path,subroutine,time" prove --verbose --parse -It -Ilib/ t/*.t'
     - docker run -it --rm -v $PWD:/opt/microPIECE -v /tmp/microPIECE-testset:/tmp/microPIECE-testset micropiece/micropiece /opt/microPIECE/t/run_clip.sh
     - docker run -it --rm -v $PWD:/opt/microPIECE -v /tmp/microPIECE-testset:/tmp/microPIECE-testset micropiece/micropiece /opt/microPIECE/t/run_complete.sh
     - docker run -it --rm -v $PWD:/opt/microPIECE -v /tmp/microPIECE-testset:/tmp/microPIECE-testset micropiece/micropiece chmod -R a+wrX /opt/microPIECE/cover_db

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN echo "VCS_REF: "${VCS_REF}", BUILD_DATE: "${BUILD_DATE}", micropiece_version
 
 LABEL maintainer="frank.foerster@ime.fraunhofer.de" \
       description="Container for the microPIECE package" \
-      version="1.0" \
+      version="1.2.1" \
       org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.vcs-url="https://github.com/microPIECE-team/microPIECE"

--- a/lib/microPIECE.pm
+++ b/lib/microPIECE.pm
@@ -3,7 +3,7 @@ package microPIECE;
 use strict;
 use warnings;
 
-use version 0.77; our $VERSION = version->declare("v1.2.0");
+use version 0.77; our $VERSION = version->declare("v1.2.1");
 
 use Log::Log4perl;
 use Data::Dumper;

--- a/scripts/MINING_curate_mirdeep2fasta.pl
+++ b/scripts/MINING_curate_mirdeep2fasta.pl
@@ -60,8 +60,8 @@ foreach(keys %novel_hash){
 
 	my $header	= sprintf(">%s-new-%d", $species, $novel_count);
 
-	print HAIRPIN "$header\n$hairpin\n";
-	print MATURE "$header-5p\n$mature5p\n$header-3p\n$mature3p\n";
+        print HAIRPIN $header, "\n", $hairpin, "\n";
+        print MATURE  $header, "-5p\n", $mature5p, "\n", $header, "-3p\n", $mature3p, "\n";
 }
 #close(CSV) || die;
 

--- a/scripts/MINING_curate_mirdeep2fasta.pl
+++ b/scripts/MINING_curate_mirdeep2fasta.pl
@@ -1,7 +1,8 @@
-#! /usr/bin/perl
+#!/usr/bin/perl
 use strict;
 use warnings;
 use Getopt::Long;
+
 my $csv_file;
 my $cutoff;
 my $mature_file;
@@ -21,7 +22,6 @@ die "Need to specify --cutoff cutoffscore\n" unless (defined $cutoff);
 die "Need to specify --matureout file\n" unless (defined $mature_file);
 die "Need to specify --hairpinout file\n" unless (defined $hairpin_file);
 die "Need to specify --species three-letter-species-code\n" unless (defined $species);
-
 
 # get novel miRNAs above threshold
 my %novel_hash	= %{&parse_mirdeep($csv_file,$cutoff)};

--- a/scripts/MINING_curate_mirdeep2fasta.pl
+++ b/scripts/MINING_curate_mirdeep2fasta.pl
@@ -22,6 +22,7 @@ die "Need to specify --csv file\n" unless (defined $csv_file);
 die "Input file does not exist\n" unless (-e $csv_file);
 die "Need to specify --cutoff cutoffscore\n" unless (defined $cutoff);
 die "Need to specify --matureout file\n" unless (defined $mature_file);
+die "Mature file exists and will not be overwritten!\n" if (-e $mature_file);
 die "Need to specify --hairpinout file\n" unless (defined $hairpin_file);
 die "Need to specify --species three-letter-species-code\n" unless (defined $species);
 

--- a/scripts/MINING_curate_mirdeep2fasta.pl
+++ b/scripts/MINING_curate_mirdeep2fasta.pl
@@ -56,6 +56,7 @@ close(HAIRPIN)|| die "Unable to close file '$hairpin_file': $!\n";
 sub parse_mirdeep{
         my ($file, $cutoff)     = @_;
         my @result = ();
+	my %seen   = ();
 
         open(PM, "<", $file) || die "Unable to open file '$file': $!\n";
         while(<PM>){
@@ -114,6 +115,8 @@ sub parse_mirdeep{
 		$ctx->add(join("|", $dataset{precursor_seq}, $dataset{mature_seq}, $dataset{star_seq}));
 		my @checksum = unpack("S*", $ctx->digest); # digest is 16 Bytes... We are using the lowest 16 bit as unsigned number (ranging 0-65535) as digest
 		$dataset{digest} = $checksum[-1];
+		die "Collision detected\n" if (exists $seen{$checksum[-1]});
+		$seen{$checksum[-1]}++;
 		push(@result, \%dataset);
 	    }
 

--- a/scripts/MINING_curate_mirdeep2fasta.pl
+++ b/scripts/MINING_curate_mirdeep2fasta.pl
@@ -24,6 +24,7 @@ die "Need to specify --cutoff cutoffscore\n" unless (defined $cutoff);
 die "Need to specify --matureout file\n" unless (defined $mature_file);
 die "Mature file exists and will not be overwritten!\n" if (-e $mature_file);
 die "Need to specify --hairpinout file\n" unless (defined $hairpin_file);
+die "Hairpin file exists and will not be overwritten!\n" if (-e $hairpin_file);
 die "Need to specify --species three-letter-species-code\n" unless (defined $species);
 
 # get novel miRNAs above threshold

--- a/scripts/MINING_curate_mirdeep2fasta.pl
+++ b/scripts/MINING_curate_mirdeep2fasta.pl
@@ -19,6 +19,7 @@ GetOptions(
 ) || die;
 
 die "Need to specify --csv file\n" unless (defined $csv_file);
+die "Input file does not exist\n" unless (-e $csv_file);
 die "Need to specify --cutoff cutoffscore\n" unless (defined $cutoff);
 die "Need to specify --matureout file\n" unless (defined $mature_file);
 die "Need to specify --hairpinout file\n" unless (defined $hairpin_file);

--- a/scripts/MINING_curate_mirdeep2fasta.pl
+++ b/scripts/MINING_curate_mirdeep2fasta.pl
@@ -65,9 +65,8 @@ foreach(keys %novel_hash){
 }
 #close(CSV) || die;
 
-close(MATURE) || die "$!";
-close(HAIRPIN)|| die "$!";
-
+close(MATURE) || die "Unable to close file '$mature_file': $!\n";
+close(HAIRPIN)|| die "Unable to close file '$hairpin_file': $!\n";
 
 ###########################################################################
 

--- a/scripts/MINING_curate_mirdeep2fasta.pl
+++ b/scripts/MINING_curate_mirdeep2fasta.pl
@@ -26,8 +26,8 @@ die "Need to specify --species three-letter-species-code\n" unless (defined $spe
 # get novel miRNAs above threshold
 my %novel_hash	= %{&parse_mirdeep($csv_file,$cutoff)};
 
-open(MATURE,">",$mature_file) || die "$!";
-open(HAIRPIN,">",$hairpin_file) || die "$!";
+open(MATURE,">",$mature_file)   || die "Unable to open file '$mature_file': $!\n";
+open(HAIRPIN,">",$hairpin_file) || die "Unable to open file '$hairpin_file': $!\n";
 
 foreach(keys %novel_hash){
 	my $novel_count	= $_;

--- a/t/MINING_curate_mirdeep2fasta.t
+++ b/t/MINING_curate_mirdeep2fasta.t
@@ -55,6 +55,8 @@ foreach my $current_test (@testcases)
 						"--species", "tca"
 					    ] );
     is(Test::Script::Run::last_script_exit_code(), 0, 'With value for hairpin is should exit with exit code not equals to 0');
+    diag($stdout);
+    diag($stderr);
 
     my $got	= parser($mature, $hairpin);
     is($got,$current_test->{expected}, "output for input: '".$current_test->{input}."' as expected");

--- a/t/MINING_curate_mirdeep2fasta.t
+++ b/t/MINING_curate_mirdeep2fasta.t
@@ -10,7 +10,11 @@ use Digest::MD5;
 my @testcases = (
     {
 	input => "MINING_curate_mirdeep2fasta_case1.dat",
-	expected => "212d519b1d185ce0998bf52a33e891b5",
+	expected => "b5f303bb04b2a8947652bcab1a9171f4",
+    },
+    {
+	input => "MINING_curate_mirdeep2fasta_case2.dat",
+	expected => "b5f303bb04b2a8947652bcab1a9171f4",
     }
     );
 

--- a/t/MINING_curate_mirdeep2fasta.t
+++ b/t/MINING_curate_mirdeep2fasta.t
@@ -10,11 +10,15 @@ use Digest::MD5;
 my @testcases = (
     {
 	input => "t/MINING_curate_mirdeep2fasta_case1.dat",
-	expected => "b5f303bb04b2a8947652bcab1a9171f4",
+	expected => "a545dbc1e0ea240c00dd54032707ed44",
     },
     {
 	input => "t/MINING_curate_mirdeep2fasta_case2.dat",
-	expected => "b5f303bb04b2a8947652bcab1a9171f4",
+	expected => "a545dbc1e0ea240c00dd54032707ed44",
+    },
+    {
+	input => "t/MINING_curate_mirdeep2fasta_case3.dat",
+	expected => "a545dbc1e0ea240c00dd54032707ed44",
     }
     );
 

--- a/t/MINING_curate_mirdeep2fasta.t
+++ b/t/MINING_curate_mirdeep2fasta.t
@@ -33,6 +33,10 @@ like($stderr, qr/Need to specify --csv file/, "Test for missing csv file");
 isnt(Test::Script::Run::last_script_exit_code(), 0, 'With file for query is should exit with exit code not equals to 0');
 like($stderr, qr/Need to specify --cutoff cutoffscore/, "Test for missing cutoff");
 
+($return,$stdout,$stderr)=run_script('../scripts/MINING_curate_mirdeep2fasta.pl', ["--csv", $testcases[0]{input}."non_existing" ] );
+isnt(Test::Script::Run::last_script_exit_code(), 0, 'With non existing file for query is should exit with exit code not equals to 0');
+like($stderr, qr/Input file does not exist/, "Test for non-existing input file");
+
 ($return,$stdout,$stderr)=run_script('../scripts/MINING_curate_mirdeep2fasta.pl', ["--csv", $testcases[0]{input}, "--cutoff", 10 ] );
 isnt(Test::Script::Run::last_script_exit_code(), 0, 'With value for cufoff is should exit with exit code not equals to 0');
 like($stderr, qr/Need to specify --matureout file/, "Test for missing matureout file");

--- a/t/MINING_curate_mirdeep2fasta.t
+++ b/t/MINING_curate_mirdeep2fasta.t
@@ -45,6 +45,9 @@ like($stderr, qr/Need to specify --hairpinout file/, "Test for missing hairpinou
 isnt(Test::Script::Run::last_script_exit_code(), 0, 'With value for hairpin is should exit with exit code not equals to 0');
 like($stderr, qr/Need to specify --species three-letter-species-code/, "Test for missing species");
 
+($return,$stdout,$stderr)=run_script('../scripts/MINING_curate_mirdeep2fasta.pl', ["--csv", "t/MINING_curate_mirdeep2fasta_collision.dat", "--cutoff", 10, "--matureout", $mature, "--hairpinout", $hairpin, "--species", "tca" ] );
+isnt(Test::Script::Run::last_script_exit_code(), 0, 'Collision should cause the exit code not equals to 0');
+like($stderr, qr/Collision detected/, "Test for collision in numbering");
 
 foreach my $current_test (@testcases)
 {

--- a/t/MINING_curate_mirdeep2fasta.t
+++ b/t/MINING_curate_mirdeep2fasta.t
@@ -4,7 +4,7 @@ use warnings;
 use Test::Script::Run;
 use Test::More;
 
-use File::Temp;
+use File::Temp qw/ :POSIX /;
 use Digest::MD5;
 
 my @testcases = (
@@ -18,8 +18,8 @@ my @testcases = (
     }
     );
 
-my (undef, $mature)  = File::Temp::tempfile(OPEN => 0);
-my (undef, $hairpin) = File::Temp::tempfile(OPEN => 0);
+my $mature  = tmpnam();
+my $hairpin = tmpnam();
 
 my ($return,$stdout,$stderr)=run_script('../scripts/MINING_curate_mirdeep2fasta.pl');
 isnt(Test::Script::Run::last_script_exit_code(), 0, 'Without arguments is should exit with exit code not equals to 1');

--- a/t/MINING_curate_mirdeep2fasta.t
+++ b/t/MINING_curate_mirdeep2fasta.t
@@ -44,6 +44,9 @@ like($stderr, qr/Need to specify --species three-letter-species-code/, "Test for
 
 foreach my $current_test (@testcases)
 {
+    my $mature  = tmpnam();
+    my $hairpin = tmpnam();
+
     my ($return,$stdout,$stderr)=run_script('../scripts/MINING_curate_mirdeep2fasta.pl', [
 						"--csv", $current_test->{input}, 
 						"--cutoff", 10, 

--- a/t/MINING_curate_mirdeep2fasta.t
+++ b/t/MINING_curate_mirdeep2fasta.t
@@ -1,0 +1,76 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::Script::Run;
+use Test::More;
+
+use File::Temp;
+use Digest::MD5;
+
+my @testcases = (
+    {
+	input => "MINING_curate_mirdeep2fasta_case1.dat",
+	expected => "212d519b1d185ce0998bf52a33e891b5",
+    }
+    );
+
+my (undef, $mature)  = File::Temp::tempfile(OPEN => 0);
+my (undef, $hairpin) = File::Temp::tempfile(OPEN => 0);
+
+my ($return,$stdout,$stderr)=run_script('../scripts/MINING_curate_mirdeep2fasta.pl');
+isnt(Test::Script::Run::last_script_exit_code(), 0, 'Without arguments is should exit with exit code not equals to 1');
+like($stderr, qr/Need to specify --csv file/, "Test for missing csv file");
+
+($return,$stdout,$stderr)=run_script('../scripts/MINING_curate_mirdeep2fasta.pl', ["--csv", $testcases[0]{input} ] );
+isnt(Test::Script::Run::last_script_exit_code(), 0, 'With file for query is should exit with exit code not equals to 0');
+like($stderr, qr/Need to specify --cutoff cutoffscore/, "Test for missing cutoff");
+
+($return,$stdout,$stderr)=run_script('../scripts/MINING_curate_mirdeep2fasta.pl', ["--csv", $testcases[0]{input}, "--cutoff", 10 ] );
+isnt(Test::Script::Run::last_script_exit_code(), 0, 'With value for cufoff is should exit with exit code not equals to 0');
+like($stderr, qr/Need to specify --matureout file/, "Test for missing matureout file");
+
+($return,$stdout,$stderr)=run_script('../scripts/MINING_curate_mirdeep2fasta.pl', ["--csv", $testcases[0]{input}, "--cutoff", 10, "--matureout", $mature ] );
+isnt(Test::Script::Run::last_script_exit_code(), 0, 'With value for mature is should exit with exit code not equals to 0');
+like($stderr, qr/Need to specify --hairpinout file/, "Test for missing hairpinout file");
+
+($return,$stdout,$stderr)=run_script('../scripts/MINING_curate_mirdeep2fasta.pl', ["--csv", $testcases[0]{input}, "--cutoff", 10, "--matureout", $mature, "--hairpinout", $hairpin ] );
+isnt(Test::Script::Run::last_script_exit_code(), 0, 'With value for hairpin is should exit with exit code not equals to 0');
+like($stderr, qr/Need to specify --species three-letter-species-code/, "Test for missing species");
+
+
+foreach my $current_test (@testcases)
+{
+    my ($return,$stdout,$stderr)=run_script('../scripts/MINING_curate_mirdeep2fasta.pl', [
+						"--csv", $current_test->{input}, 
+						"--cutoff", 10, 
+						"--matureout", $mature, 
+						"--hairpinout", $hairpin, 
+						"--species", "tca"
+					    ] );
+    is(Test::Script::Run::last_script_exit_code(), 0, 'With value for hairpin is should exit with exit code not equals to 0');
+
+    my $got	= parser($mature, $hairpin);
+    is($got,$current_test->{expected}, "output for input: '".$current_test->{input}."' as expected");
+}
+
+done_testing();
+
+sub parser
+{
+    my @files = @_;
+
+    my $ctx = Digest::MD5->new;
+    
+    foreach my $file (@files)
+    {
+	open(my $fh, "<", $file) || die "Unable to open input file '$file': $!\n";
+	#	$ctx->add($fh);
+	while (<$fh>)
+	{
+	    $ctx->add($_);
+	}
+	close($fh) || die "Unable to close input file '$file': $!\n";
+    }
+    
+    return $ctx->hexdigest();
+}

--- a/t/MINING_curate_mirdeep2fasta.t
+++ b/t/MINING_curate_mirdeep2fasta.t
@@ -45,6 +45,10 @@ like($stderr, qr/Need to specify --matureout file/, "Test for missing matureout 
 isnt(Test::Script::Run::last_script_exit_code(), 0, 'With value for mature is should exit with exit code not equals to 0');
 like($stderr, qr/Need to specify --hairpinout file/, "Test for missing hairpinout file");
 
+($return,$stdout,$stderr)=run_script('../scripts/MINING_curate_mirdeep2fasta.pl', ["--csv", $testcases[0]{input}, "--cutoff", 10, "--matureout", $testcases[0]{input} ] );
+isnt(Test::Script::Run::last_script_exit_code(), 0, 'With an existing file for mature sequences is should exit with exit code not equals to 0');
+like($stderr, qr/Mature file exists and will not be overwritten/, "Test for existing mature file");
+
 ($return,$stdout,$stderr)=run_script('../scripts/MINING_curate_mirdeep2fasta.pl', ["--csv", $testcases[0]{input}, "--cutoff", 10, "--matureout", $mature, "--hairpinout", $hairpin ] );
 isnt(Test::Script::Run::last_script_exit_code(), 0, 'With value for hairpin is should exit with exit code not equals to 0');
 like($stderr, qr/Need to specify --species three-letter-species-code/, "Test for missing species");
@@ -66,6 +70,8 @@ foreach my $current_test (@testcases)
 
     my $got	= parser($mature, $hairpin);
     is($got,$current_test->{expected}, "output for input: '".$current_test->{input}."' as expected");
+    unlink($mature) || die "Unable to unlink mature file '$mature': $!\n";
+    unlink($hairpin) || die "Unable to unlink hairpin file '$hairpin': $!\n";
 }
 
 done_testing();

--- a/t/MINING_curate_mirdeep2fasta.t
+++ b/t/MINING_curate_mirdeep2fasta.t
@@ -53,6 +53,10 @@ like($stderr, qr/Mature file exists and will not be overwritten/, "Test for exis
 isnt(Test::Script::Run::last_script_exit_code(), 0, 'With value for hairpin is should exit with exit code not equals to 0');
 like($stderr, qr/Need to specify --species three-letter-species-code/, "Test for missing species");
 
+($return,$stdout,$stderr)=run_script('../scripts/MINING_curate_mirdeep2fasta.pl', ["--csv", $testcases[0]{input}, "--cutoff", 10, "--matureout", $mature, "--hairpinout", $testcases[0]{input} ] );
+isnt(Test::Script::Run::last_script_exit_code(), 0, 'With an existing file for hairpin sequences is should exit with exit code not equals to 0');
+like($stderr, qr/Hairpin file exists and will not be overwritten/, "Test for existing hairpin file");
+
 ($return,$stdout,$stderr)=run_script('../scripts/MINING_curate_mirdeep2fasta.pl', ["--csv", "t/MINING_curate_mirdeep2fasta_collision.dat", "--cutoff", 10, "--matureout", $mature, "--hairpinout", $hairpin, "--species", "tca" ] );
 isnt(Test::Script::Run::last_script_exit_code(), 0, 'Collision should cause the exit code not equals to 0');
 like($stderr, qr/Collision detected/, "Test for collision in numbering");

--- a/t/MINING_curate_mirdeep2fasta.t
+++ b/t/MINING_curate_mirdeep2fasta.t
@@ -9,11 +9,11 @@ use Digest::MD5;
 
 my @testcases = (
     {
-	input => "MINING_curate_mirdeep2fasta_case1.dat",
+	input => "t/MINING_curate_mirdeep2fasta_case1.dat",
 	expected => "b5f303bb04b2a8947652bcab1a9171f4",
     },
     {
-	input => "MINING_curate_mirdeep2fasta_case2.dat",
+	input => "t/MINING_curate_mirdeep2fasta_case2.dat",
 	expected => "b5f303bb04b2a8947652bcab1a9171f4",
     }
     );
@@ -44,9 +44,6 @@ like($stderr, qr/Need to specify --species three-letter-species-code/, "Test for
 
 foreach my $current_test (@testcases)
 {
-    my $mature  = tmpnam();
-    my $hairpin = tmpnam();
-
     my ($return,$stdout,$stderr)=run_script('../scripts/MINING_curate_mirdeep2fasta.pl', [
 						"--csv", $current_test->{input}, 
 						"--cutoff", 10, 
@@ -54,9 +51,7 @@ foreach my $current_test (@testcases)
 						"--hairpinout", $hairpin, 
 						"--species", "tca"
 					    ] );
-    is(Test::Script::Run::last_script_exit_code(), 0, 'With value for hairpin is should exit with exit code not equals to 0');
-    diag($stdout);
-    diag($stderr);
+    is(Test::Script::Run::last_script_exit_code(), 0, 'With input values it should run and return 0');
 
     my $got	= parser($mature, $hairpin);
     is($got,$current_test->{expected}, "output for input: '".$current_test->{input}."' as expected");

--- a/t/MINING_curate_mirdeep2fasta_case1.dat
+++ b/t/MINING_curate_mirdeep2fasta_case1.dat
@@ -1,0 +1,67 @@
+miRDeep2 score	novel miRNAs reported by miRDeep2	novel miRNAs, estimated false positives	novel miRNAs, estimated true positives	known miRNAs in species	known miRNAs in data	known miRNAs detected by miRDeep2	estimated signal-to-noise	excision gearing
+10	10	2 +/- 1	8 +/- 1 (83 +/- 12%)	590	427	254 (59%)	38.2	3
+9	10	2 +/- 1	8 +/- 1 (82 +/- 13%)	590	427	256 (60%)	37.8	3
+8	10	2 +/- 1	8 +/- 1 (82 +/- 14%)	590	427	258 (60%)	37	3
+7	10	2 +/- 1	8 +/- 1 (81 +/- 14%)	590	427	258 (60%)	36.4	3
+6	11	2 +/- 1	9 +/- 1 (82 +/- 13%)	590	427	260 (61%)	36.2	3
+5	18	2 +/- 2	16 +/- 2 (88 +/- 8%)	590	427	300 (70%)	37.6	3
+4	27	3 +/- 2	24 +/- 2 (90 +/- 6%)	590	427	329 (77%)	31.4	3
+3	32	7 +/- 3	25 +/- 3 (78 +/- 8%)	590	427	338 (79%)	16.9	3
+2	37	12 +/- 3	25 +/- 3 (68 +/- 9%)	590	427	340 (80%)	11.7	3
+1	44	17 +/- 4	27 +/- 4 (61 +/- 10%)	590	427	347 (81%)	8.9	3
+0	53	23 +/- 5	30 +/- 5 (56 +/- 9%)	590	427	349 (82%)	7.2	3
+-1	57	31 +/- 5	26 +/- 5 (45 +/- 9%)	590	427	351 (82%)	5.7	3
+-2	66	40 +/- 6	26 +/- 6 (40 +/- 9%)	590	427	351 (82%)	4.8	3
+-3	73	48 +/- 7	25 +/- 7 (34 +/- 9%)	590	427	352 (82%)	4.2	3
+-4	81	55 +/- 7	26 +/- 7 (32 +/- 9%)	590	427	352 (82%)	3.8	3
+-5	85	63 +/- 7	22 +/- 7 (26 +/- 8%)	590	427	352 (82%)	3.5	3
+-6	87	70 +/- 8	17 +/- 8 (20 +/- 9%)	590	427	352 (82%)	3.2	3
+-7	93	75 +/- 8	18 +/- 8 (19 +/- 8%)	590	427	352 (82%)	3.1	3
+-8	95	81 +/- 8	14 +/- 8 (15 +/- 8%)	590	427	352 (82%)	2.9	3
+-9	100	85 +/- 8	15 +/- 8 (15 +/- 8%)	590	427	352 (82%)	2.9	3
+-10	103	89 +/- 8	14 +/- 8 (14 +/- 8%)	590	427	352 (82%)	2.8	3
+
+
+
+novel miRNAs predicted by miRDeep2
+provisional id	miRDeep2 score	estimated probability that the miRNA candidate is a true positive	rfam alert	total read count	mature read count	loop read count	star read count	significant randfold p-value	miRBase miRNA	example miRBase miRNA with the same seed	UCSC browser	NCBI blastn	consensus mature sequence	consensus star sequence	consensus precursor sequence	precursor coordinate
+NC_007417.3_5178	328.3	83 +/- 12%	-	649	532	0	117	yes	-	-	-	-	cuucaacucacuuuggacaacu	uuguccaacuugaguauugaga	uuguccaacuugaguauugagaacggaauuaaucucgcucuucaacucacuuuggacaacu	NC_007417.3:14308626..14308687:-
+NC_007424.3_29324	114.2	83 +/- 12%	-	221	200	0	21	yes	-	-	-	-	cuccucgcugguagauggcgggcu	ccgccaugaccggcggggcggcg	ccgccaugaccggcggggcggcgcggcucgaguugugcuccucgcugguagauggcgggcu	NC_007424.3:13942158..13942219:-
+NC_007424.3_28086	89.7	83 +/- 12%	-	175	50	0	125	yes	-	-	-	-	cggucaguaagucugcugaugcu	uuucagcucucuuacuuuccguc	cggucaguaagucugcugaugcuuuuacgacaguuucagcucucuuacuuuccguc	NC_007424.3:14276628..14276684:+
+NC_007417.3_2806	45.1	83 +/- 12%	-	94	93	0	1	yes	-	hsa-miR-5582-3p	-	-	uaaaacuucacgaacug	cauucagaaguauuaauucgga	uaaaacuucacgaacugucacguaccaugauuucaauucacuucaauuagcgacguuacauucagaaguauuaauucgga	NC_007417.3:5866105..5866185:+
+NW_015452101.1_46214	0.4	56 +/- 9%	-	4140	4138	2	0	no	-	gga-miR-1774	-	-	ucccugcucgggcgcca	gcuuugucggagaucggguug	ucccugcucgggcgccaaaauuuguaauguccuuuuuccgggcggcuuugucggagaucggguug	NW_015452101.1:671..736:+
+NC_007424.3_28116	0.3	56 +/- 9%	-	3	3	0	0	yes	-	sma-miR-8462-5p	-	-	ugauuaaucuuuacuguuacc	caaccauagagauuaaucaag	ugauuaaucuuuacuguuaccauaguuacagcauggcaaccauagagauuaaucaag	NC_007424.3:15097848..15097905:+
+NC_007419.2_12804	0.3	56 +/- 9%	-	408	407	1	0	no	-	bfl-miR-4892	-	-	guaggauaagugggagu	acuuccugccugcga	acuuccugccugcgauugggcuuuauuuaacugaguuaaaguguaggauaagugggagu	NC_007419.2:9640109..9640168:-
+NC_007425.3_29801	0.2	56 +/- 9%	-	18911	18911	0	0	yes	-	-	-	-	guucccggaccacuccc	ucguauuccgguggcaa	ucguauuccgguggcaacuuaaugauauuuugugacguucauuaagugaguuuguucccggaccacuccc	NC_007425.3:2845289..2845359:+
+NC_007419.2_12773	0	56 +/- 9%	-	4	4	0	0	yes	-	ame-miR-3790-5p	-	-	aaaagcgacuuuuuucuugcug	gcagguaaaaaaguaauuuuggc	aaaagcgacuuuuuucuugcuguuggaauaauuggcagguaaaaaaguaauuuuggc	NC_007419.2:9213500..9213557:-
+
+
+
+mature miRBase miRNAs detected by miRDeep2
+tag id	miRDeep2 score	estimated probability that the miRNA is a true positive	rfam alert	total read count	mature read count	loop read count	star read count	significant randfold p-value	mature miRBase miRNA	example miRBase miRNA with the same seed	UCSC browser	NCBI blastn	consensus mature sequence	consensus star sequence	consensus precursor sequence	precursor coordinate
+NC_007424.3_28946	1080044	83 +/- 12%	-	2118452	2095855	0	22597	yes	tca-miR-8-5p	sha-miR-200c	-	-	uaauacugucagguaaagauguc	caucuuaccgggcagcauuaga	caucuuaccgggcagcauuagauuacauuuuauacuucuaauacugucagguaaagauguc	NC_007424.3:8781912..8781973:-
+NC_007417.3_2952	960398.2	83 +/- 12%	-	1883771	1870384	0	13387	yes	tca-miR-10-5p	cpi-miR-10b-5p	-	-	uacccuguagauccgaauuugu	caaauucgguucuagagagguuu	uacccuguagauccgaauuuguuugaaaucaggcgacaaauucgguucuagagagguuu	NC_007417.3:8460382..8460441:+
+NC_007422.5_18806	699490.5	83 +/- 12%	-	1372012	1371975	0	37	yes	tca-miR-31-5p	bma-miR-72	-	-	aggcaagaugucggcauagcuga	ggcuaugucucauccggccaac	aggcaagaugucggcauagcugaagguguuugaaacggcuaugucucauccggccaac	NC_007422.5:5938428..5938486:+
+NC_007418.3_6733	364433.7	83 +/- 12%	-	714813	714478	0	335	yes	tca-bantam-5p	hpo-miR-10021-5p	-	-	ugagaucauugugaaagcugauu	cugguuuucacagugauuugac	cugguuuucacagugauuugacagauauauuugauucugagaucauugugaaagcugauu	NC_007418.3:16990365..16990425:+
+NC_007418.3_8508	298016.6	83 +/- 12%	-	584538	583631	0	907	yes	tca-miR-276-5p	der-miR-276a	-	-	uaggaacuucauaccgugcucu	agcgagguauagaguuccuacg	agcgagguauagaguuccuacgugauuuuucggcuguaggaacuucauaccgugcucu	NC_007418.3:12483937..12483995:-
+NC_007418.3_6695	280475.2	83 +/- 12%	-	550133	549894	1	238	yes	tca-miR-279c-5p	dme-miR-279-3p	-	-	ugacuagaucgaacauucgcu	cggguguucguuucgagucaca	cggguguucguuucgagucacauugugauugauuuugugacuagaucgaacauucgcu	NC_007418.3:15690068..15690126:+
+NC_007420.3_15639	260138.4	83 +/- 12%	-	510241	509166	0	1075	yes	tca-miR-263a-5p	ggo-miR-183	-	-	aauggcacuggaagaauucacggg	cguggacuuugagugccauccu	aauggcacuggaagaauucacgggguucuucgcacucccguggacuuugagugccauccu	NC_007420.3:13500412..13500472:-
+NC_007422.5_18118	225456.2	83 +/- 12%	-	442214	408799	0	33415	yes	tca-miR-281-5p	sma-miR-281-5p	-	-	aagagagcuauccgucgacagu	cugucauggaguugcucucuu	aagagagcuauccgucgacaguauauaauuuacacugucauggaguugcucucuu	NC_007422.5:203927..203982:+
+NC_007421.3_16306	196235.3	83 +/- 12%	-	384898	384031	0	867	yes	tca-miR-100-5p	cbn-miR-52	-	-	aacccguagauccgaacuugug	caaguucuuguuuauggguacc	aacccguagauccgaacuuguggggcuguggucacaaguucuuguuuauggguacc	NC_007421.3:4363293..4363349:+
+NC_007422.5_19503	155861.3	83 +/- 12%	-	305707	304852	0	855	yes	tca-miR-184-5p	cin-miR-184	-	-	uggacggagaacugauaagggc	ccuugucauucucucgcccggu	ccuugucauucucucgcccgguguauuuuaacaacuggacggagaacugauaagggc	NC_007422.5:12944303..12944360:+
+NC_007418.3_5615	136501.5	83 +/- 12%	-	267736	256940	0	10796	yes	tca-miR-14-5p	bmo-miR-3368	-	-	ucagucuuuuucucucuccuau	aggggagcggauuggacuuacu	aggggagcggauuggacuuacuuuuuuucaaacagucagucuuuuucucucuccuau	NC_007418.3:2833775..2833832:+
+NC_007416.3_1577	112414	83 +/- 12%	-	220488	217173	2	3313	yes	tca-miR-9a-5p	dse-miR-9b	-	-	ucuuugguuaucuagcuguauga	uaaagcuagguuaccggaguua	ucuuugguuaucuagcuguaugaguauuguuuaauaacaucauaaagcuagguuaccggaguua	NC_007416.3:6011260..6011324:-
+NC_007418.3_5397	99158.8	83 +/- 12%	-	194487	194476	0	11	yes	tca-miR-2-2-5p	gsa-miR-2c-3p	-	-	ucacagccagcuuugaugag	ucaucaucugguugugaaaug	ucaucaucugguugugaaaugugaauuuauaucauaucacagccagcuuugaugag	NC_007418.3:561351..561407:+
+
+#miRBase miRNAs not detected by miRDeep2
+miRBase precursor id	total read count	5p read counts	3p read counts	remaining reads	UCSC browser	NCBI blastn	miRBase 5p sequence(s)	miRBase 3p sequence(s)	miRBase precursor sequence
+53558	52520	434	604	-	-	ucccugagacccuaacuuguga	acaagcuagcgacucggguauug	auuugccuauucccugagacccuaacuugugauguuaaauggacucucacaagcuagcgacucggguauuggcggau	
+14158	281	13867	10	-	-	cgugcgaucuuuccauuccuacuug	uaguacggaauuaucucac	cucuuuucgcauuaucuuucgugcgaucuuuccauuccuacuuguuguuugauaaguaguacggaauuaucucacauuagauauugggaguuuuc	
+12365	12194	170	1	-	-	ucuuuggugaucuaguuguau	auaaagcugguucagcaaagca	aacagguugcaagucggauauauucuucuuuggugaucuaguuguaugaguguuuuauauaucauaaagcugguucagcaaagcagauugcauucgacucuucgacgagcc	
+2841	2763	14	64	-	-	acugaagcugacgaguuaacugccgg	ucccggauuuuuuccccagccucaa	aaaacugaagcugacgaguuaacugccggguacuuguucccggauuuuuuccccagccucaagaag	
+2846	2415	27	404	-	-	acccaucuucagacaacucugg	cgaguuugcuuuugaugggaga	aguguaggcgauuuugacccaucuucagacaacucuggauuguuuuaaauguccacgaguuugcuuuugaugggagaucaauagucuuuuag	
+2594	2256	1	337	-	-	ugauguuauuuucgaccucc	ucucugguagaaaguacgucau	ggauggaaugauguuauuuucgaccuccaccacccucucugguagaaaguacgucauucaccuc	
+2074	395	1677	2	-	-	cgcaggauuugcuugugaaugg	aaucacaggaaaauucugugcg	ucaaaugggguaauuggcgcccugcgcaggauuugcuugugaaugggugugcuugauucaaucacaggaaaauucugugcggggaguugguuuugucaccaca	
+848	0	848	0	-	-	uggguuauugugugccggu	aaccggccauaaagcccuc	caauuggguuauugugugccggucauuacaucauuacaggucauguaaaccggccauaaagcccucaac	
+1797	792	449	556	-	-	ugccacugaugaauuacugcuagaau	uugaggauucgcaguuucugaggcaa	uaaaaucuuguugccacugaugaauuacugcuagaaucuuccuuuaauuuaaguugaggauucgcaguuucugaggcaaauuagaaaa	
+806	79	725	2	-	-	aggggguacuguaaguacgua	uaguacgaacgguacucacuau	caucagugaaugcuuuguaggggguacuguaaguacguacgauuuuuuuaacguaguacgaacgguacucacuaugaacguuacacaguuu	

--- a/t/MINING_curate_mirdeep2fasta_case2.dat
+++ b/t/MINING_curate_mirdeep2fasta_case2.dat
@@ -1,0 +1,67 @@
+miRDeep2 score	novel miRNAs reported by miRDeep2	novel miRNAs, estimated false positives	novel miRNAs, estimated true positives	known miRNAs in species	known miRNAs in data	known miRNAs detected by miRDeep2	estimated signal-to-noise	excision gearing
+10	10	2 +/- 1	8 +/- 1 (83 +/- 12%)	590	427	254 (59%)	38.2	3
+9	10	2 +/- 1	8 +/- 1 (82 +/- 13%)	590	427	256 (60%)	37.8	3
+8	10	2 +/- 1	8 +/- 1 (82 +/- 14%)	590	427	258 (60%)	37	3
+7	10	2 +/- 1	8 +/- 1 (81 +/- 14%)	590	427	258 (60%)	36.4	3
+6	11	2 +/- 1	9 +/- 1 (82 +/- 13%)	590	427	260 (61%)	36.2	3
+5	18	2 +/- 2	16 +/- 2 (88 +/- 8%)	590	427	300 (70%)	37.6	3
+4	27	3 +/- 2	24 +/- 2 (90 +/- 6%)	590	427	329 (77%)	31.4	3
+3	32	7 +/- 3	25 +/- 3 (78 +/- 8%)	590	427	338 (79%)	16.9	3
+2	37	12 +/- 3	25 +/- 3 (68 +/- 9%)	590	427	340 (80%)	11.7	3
+1	44	17 +/- 4	27 +/- 4 (61 +/- 10%)	590	427	347 (81%)	8.9	3
+0	53	23 +/- 5	30 +/- 5 (56 +/- 9%)	590	427	349 (82%)	7.2	3
+-1	57	31 +/- 5	26 +/- 5 (45 +/- 9%)	590	427	351 (82%)	5.7	3
+-2	66	40 +/- 6	26 +/- 6 (40 +/- 9%)	590	427	351 (82%)	4.8	3
+-3	73	48 +/- 7	25 +/- 7 (34 +/- 9%)	590	427	352 (82%)	4.2	3
+-4	81	55 +/- 7	26 +/- 7 (32 +/- 9%)	590	427	352 (82%)	3.8	3
+-5	85	63 +/- 7	22 +/- 7 (26 +/- 8%)	590	427	352 (82%)	3.5	3
+-6	87	70 +/- 8	17 +/- 8 (20 +/- 9%)	590	427	352 (82%)	3.2	3
+-7	93	75 +/- 8	18 +/- 8 (19 +/- 8%)	590	427	352 (82%)	3.1	3
+-8	95	81 +/- 8	14 +/- 8 (15 +/- 8%)	590	427	352 (82%)	2.9	3
+-9	100	85 +/- 8	15 +/- 8 (15 +/- 8%)	590	427	352 (82%)	2.9	3
+-10	103	89 +/- 8	14 +/- 8 (14 +/- 8%)	590	427	352 (82%)	2.8	3
+
+
+
+novel miRNAs predicted by miRDeep2
+provisional id	miRDeep2 score	estimated probability that the miRNA candidate is a true positive	rfam alert	total read count	mature read count	loop read count	star read count	significant randfold p-value	miRBase miRNA	example miRBase miRNA with the same seed	UCSC browser	NCBI blastn	consensus mature sequence	consensus star sequence	consensus precursor sequence	precursor coordinate
+NC_007424.3_29324	114.2	83 +/- 12%	-	221	200	0	21	yes	-	-	-	-	cuccucgcugguagauggcgggcu	ccgccaugaccggcggggcggcg	ccgccaugaccggcggggcggcgcggcucgaguugugcuccucgcugguagauggcgggcu	NC_007424.3:13942158..13942219:-
+NC_007417.3_5178	328.3	83 +/- 12%	-	649	532	0	117	yes	-	-	-	-	cuucaacucacuuuggacaacu	uuguccaacuugaguauugaga	uuguccaacuugaguauugagaacggaauuaaucucgcucuucaacucacuuuggacaacu	NC_007417.3:14308626..14308687:-
+NC_007424.3_28086	89.7	83 +/- 12%	-	175	50	0	125	yes	-	-	-	-	cggucaguaagucugcugaugcu	uuucagcucucuuacuuuccguc	cggucaguaagucugcugaugcuuuuacgacaguuucagcucucuuacuuuccguc	NC_007424.3:14276628..14276684:+
+NC_007417.3_2806	45.1	83 +/- 12%	-	94	93	0	1	yes	-	hsa-miR-5582-3p	-	-	uaaaacuucacgaacug	cauucagaaguauuaauucgga	uaaaacuucacgaacugucacguaccaugauuucaauucacuucaauuagcgacguuacauucagaaguauuaauucgga	NC_007417.3:5866105..5866185:+
+NW_015452101.1_46214	0.4	56 +/- 9%	-	4140	4138	2	0	no	-	gga-miR-1774	-	-	ucccugcucgggcgcca	gcuuugucggagaucggguug	ucccugcucgggcgccaaaauuuguaauguccuuuuuccgggcggcuuugucggagaucggguug	NW_015452101.1:671..736:+
+NC_007424.3_28116	0.3	56 +/- 9%	-	3	3	0	0	yes	-	sma-miR-8462-5p	-	-	ugauuaaucuuuacuguuacc	caaccauagagauuaaucaag	ugauuaaucuuuacuguuaccauaguuacagcauggcaaccauagagauuaaucaag	NC_007424.3:15097848..15097905:+
+NC_007419.2_12804	0.3	56 +/- 9%	-	408	407	1	0	no	-	bfl-miR-4892	-	-	guaggauaagugggagu	acuuccugccugcga	acuuccugccugcgauugggcuuuauuuaacugaguuaaaguguaggauaagugggagu	NC_007419.2:9640109..9640168:-
+NC_007425.3_29801	0.2	56 +/- 9%	-	18911	18911	0	0	yes	-	-	-	-	guucccggaccacuccc	ucguauuccgguggcaa	ucguauuccgguggcaacuuaaugauauuuugugacguucauuaagugaguuuguucccggaccacuccc	NC_007425.3:2845289..2845359:+
+NC_007419.2_12773	0	56 +/- 9%	-	4	4	0	0	yes	-	ame-miR-3790-5p	-	-	aaaagcgacuuuuuucuugcug	gcagguaaaaaaguaauuuuggc	aaaagcgacuuuuuucuugcuguuggaauaauuggcagguaaaaaaguaauuuuggc	NC_007419.2:9213500..9213557:-
+
+
+
+mature miRBase miRNAs detected by miRDeep2
+tag id	miRDeep2 score	estimated probability that the miRNA is a true positive	rfam alert	total read count	mature read count	loop read count	star read count	significant randfold p-value	mature miRBase miRNA	example miRBase miRNA with the same seed	UCSC browser	NCBI blastn	consensus mature sequence	consensus star sequence	consensus precursor sequence	precursor coordinate
+NC_007424.3_28946	1080044	83 +/- 12%	-	2118452	2095855	0	22597	yes	tca-miR-8-5p	sha-miR-200c	-	-	uaauacugucagguaaagauguc	caucuuaccgggcagcauuaga	caucuuaccgggcagcauuagauuacauuuuauacuucuaauacugucagguaaagauguc	NC_007424.3:8781912..8781973:-
+NC_007417.3_2952	960398.2	83 +/- 12%	-	1883771	1870384	0	13387	yes	tca-miR-10-5p	cpi-miR-10b-5p	-	-	uacccuguagauccgaauuugu	caaauucgguucuagagagguuu	uacccuguagauccgaauuuguuugaaaucaggcgacaaauucgguucuagagagguuu	NC_007417.3:8460382..8460441:+
+NC_007422.5_18806	699490.5	83 +/- 12%	-	1372012	1371975	0	37	yes	tca-miR-31-5p	bma-miR-72	-	-	aggcaagaugucggcauagcuga	ggcuaugucucauccggccaac	aggcaagaugucggcauagcugaagguguuugaaacggcuaugucucauccggccaac	NC_007422.5:5938428..5938486:+
+NC_007418.3_6733	364433.7	83 +/- 12%	-	714813	714478	0	335	yes	tca-bantam-5p	hpo-miR-10021-5p	-	-	ugagaucauugugaaagcugauu	cugguuuucacagugauuugac	cugguuuucacagugauuugacagauauauuugauucugagaucauugugaaagcugauu	NC_007418.3:16990365..16990425:+
+NC_007418.3_8508	298016.6	83 +/- 12%	-	584538	583631	0	907	yes	tca-miR-276-5p	der-miR-276a	-	-	uaggaacuucauaccgugcucu	agcgagguauagaguuccuacg	agcgagguauagaguuccuacgugauuuuucggcuguaggaacuucauaccgugcucu	NC_007418.3:12483937..12483995:-
+NC_007418.3_6695	280475.2	83 +/- 12%	-	550133	549894	1	238	yes	tca-miR-279c-5p	dme-miR-279-3p	-	-	ugacuagaucgaacauucgcu	cggguguucguuucgagucaca	cggguguucguuucgagucacauugugauugauuuugugacuagaucgaacauucgcu	NC_007418.3:15690068..15690126:+
+NC_007420.3_15639	260138.4	83 +/- 12%	-	510241	509166	0	1075	yes	tca-miR-263a-5p	ggo-miR-183	-	-	aauggcacuggaagaauucacggg	cguggacuuugagugccauccu	aauggcacuggaagaauucacgggguucuucgcacucccguggacuuugagugccauccu	NC_007420.3:13500412..13500472:-
+NC_007422.5_18118	225456.2	83 +/- 12%	-	442214	408799	0	33415	yes	tca-miR-281-5p	sma-miR-281-5p	-	-	aagagagcuauccgucgacagu	cugucauggaguugcucucuu	aagagagcuauccgucgacaguauauaauuuacacugucauggaguugcucucuu	NC_007422.5:203927..203982:+
+NC_007421.3_16306	196235.3	83 +/- 12%	-	384898	384031	0	867	yes	tca-miR-100-5p	cbn-miR-52	-	-	aacccguagauccgaacuugug	caaguucuuguuuauggguacc	aacccguagauccgaacuuguggggcuguggucacaaguucuuguuuauggguacc	NC_007421.3:4363293..4363349:+
+NC_007422.5_19503	155861.3	83 +/- 12%	-	305707	304852	0	855	yes	tca-miR-184-5p	cin-miR-184	-	-	uggacggagaacugauaagggc	ccuugucauucucucgcccggu	ccuugucauucucucgcccgguguauuuuaacaacuggacggagaacugauaagggc	NC_007422.5:12944303..12944360:+
+NC_007418.3_5615	136501.5	83 +/- 12%	-	267736	256940	0	10796	yes	tca-miR-14-5p	bmo-miR-3368	-	-	ucagucuuuuucucucuccuau	aggggagcggauuggacuuacu	aggggagcggauuggacuuacuuuuuuucaaacagucagucuuuuucucucuccuau	NC_007418.3:2833775..2833832:+
+NC_007416.3_1577	112414	83 +/- 12%	-	220488	217173	2	3313	yes	tca-miR-9a-5p	dse-miR-9b	-	-	ucuuugguuaucuagcuguauga	uaaagcuagguuaccggaguua	ucuuugguuaucuagcuguaugaguauuguuuaauaacaucauaaagcuagguuaccggaguua	NC_007416.3:6011260..6011324:-
+NC_007418.3_5397	99158.8	83 +/- 12%	-	194487	194476	0	11	yes	tca-miR-2-2-5p	gsa-miR-2c-3p	-	-	ucacagccagcuuugaugag	ucaucaucugguugugaaaug	ucaucaucugguugugaaaugugaauuuauaucauaucacagccagcuuugaugag	NC_007418.3:561351..561407:+
+
+#miRBase miRNAs not detected by miRDeep2
+miRBase precursor id	total read count	5p read counts	3p read counts	remaining reads	UCSC browser	NCBI blastn	miRBase 5p sequence(s)	miRBase 3p sequence(s)	miRBase precursor sequence
+53558	52520	434	604	-	-	ucccugagacccuaacuuguga	acaagcuagcgacucggguauug	auuugccuauucccugagacccuaacuugugauguuaaauggacucucacaagcuagcgacucggguauuggcggau	
+14158	281	13867	10	-	-	cgugcgaucuuuccauuccuacuug	uaguacggaauuaucucac	cucuuuucgcauuaucuuucgugcgaucuuuccauuccuacuuguuguuugauaaguaguacggaauuaucucacauuagauauugggaguuuuc	
+12365	12194	170	1	-	-	ucuuuggugaucuaguuguau	auaaagcugguucagcaaagca	aacagguugcaagucggauauauucuucuuuggugaucuaguuguaugaguguuuuauauaucauaaagcugguucagcaaagcagauugcauucgacucuucgacgagcc	
+2841	2763	14	64	-	-	acugaagcugacgaguuaacugccgg	ucccggauuuuuuccccagccucaa	aaaacugaagcugacgaguuaacugccggguacuuguucccggauuuuuuccccagccucaagaag	
+2846	2415	27	404	-	-	acccaucuucagacaacucugg	cgaguuugcuuuugaugggaga	aguguaggcgauuuugacccaucuucagacaacucuggauuguuuuaaauguccacgaguuugcuuuugaugggagaucaauagucuuuuag	
+2594	2256	1	337	-	-	ugauguuauuuucgaccucc	ucucugguagaaaguacgucau	ggauggaaugauguuauuuucgaccuccaccacccucucugguagaaaguacgucauucaccuc	
+2074	395	1677	2	-	-	cgcaggauuugcuugugaaugg	aaucacaggaaaauucugugcg	ucaaaugggguaauuggcgcccugcgcaggauuugcuugugaaugggugugcuugauucaaucacaggaaaauucugugcggggaguugguuuugucaccaca	
+848	0	848	0	-	-	uggguuauugugugccggu	aaccggccauaaagcccuc	caauuggguuauugugugccggucauuacaucauuacaggucauguaaaccggccauaaagcccucaac	
+1797	792	449	556	-	-	ugccacugaugaauuacugcuagaau	uugaggauucgcaguuucugaggcaa	uaaaaucuuguugccacugaugaauuacugcuagaaucuuccuuuaauuuaaguugaggauucgcaguuucugaggcaaauuagaaaa	
+806	79	725	2	-	-	aggggguacuguaaguacgua	uaguacgaacgguacucacuau	caucagugaaugcuuuguaggggguacuguaaguacguacgauuuuuuuaacguaguacgaacgguacucacuaugaacguuacacaguuu	

--- a/t/MINING_curate_mirdeep2fasta_case3.dat
+++ b/t/MINING_curate_mirdeep2fasta_case3.dat
@@ -1,0 +1,67 @@
+miRDeep2 score	novel miRNAs reported by miRDeep2	novel miRNAs, estimated false positives	novel miRNAs, estimated true positives	known miRNAs in species	known miRNAs in data	known miRNAs detected by miRDeep2	estimated signal-to-noise	excision gearing
+10	10	2 +/- 1	8 +/- 1 (83 +/- 12%)	590	427	254 (59%)	38.2	3
+9	10	2 +/- 1	8 +/- 1 (82 +/- 13%)	590	427	256 (60%)	37.8	3
+8	10	2 +/- 1	8 +/- 1 (82 +/- 14%)	590	427	258 (60%)	37	3
+7	10	2 +/- 1	8 +/- 1 (81 +/- 14%)	590	427	258 (60%)	36.4	3
+6	11	2 +/- 1	9 +/- 1 (82 +/- 13%)	590	427	260 (61%)	36.2	3
+5	18	2 +/- 2	16 +/- 2 (88 +/- 8%)	590	427	300 (70%)	37.6	3
+4	27	3 +/- 2	24 +/- 2 (90 +/- 6%)	590	427	329 (77%)	31.4	3
+3	32	7 +/- 3	25 +/- 3 (78 +/- 8%)	590	427	338 (79%)	16.9	3
+2	37	12 +/- 3	25 +/- 3 (68 +/- 9%)	590	427	340 (80%)	11.7	3
+1	44	17 +/- 4	27 +/- 4 (61 +/- 10%)	590	427	347 (81%)	8.9	3
+0	53	23 +/- 5	30 +/- 5 (56 +/- 9%)	590	427	349 (82%)	7.2	3
+-1	57	31 +/- 5	26 +/- 5 (45 +/- 9%)	590	427	351 (82%)	5.7	3
+-2	66	40 +/- 6	26 +/- 6 (40 +/- 9%)	590	427	351 (82%)	4.8	3
+-3	73	48 +/- 7	25 +/- 7 (34 +/- 9%)	590	427	352 (82%)	4.2	3
+-4	81	55 +/- 7	26 +/- 7 (32 +/- 9%)	590	427	352 (82%)	3.8	3
+-5	85	63 +/- 7	22 +/- 7 (26 +/- 8%)	590	427	352 (82%)	3.5	3
+-6	87	70 +/- 8	17 +/- 8 (20 +/- 9%)	590	427	352 (82%)	3.2	3
+-7	93	75 +/- 8	18 +/- 8 (19 +/- 8%)	590	427	352 (82%)	3.1	3
+-8	95	81 +/- 8	14 +/- 8 (15 +/- 8%)	590	427	352 (82%)	2.9	3
+-9	100	85 +/- 8	15 +/- 8 (15 +/- 8%)	590	427	352 (82%)	2.9	3
+-10	103	89 +/- 8	14 +/- 8 (14 +/- 8%)	590	427	352 (82%)	2.8	3
+
+
+
+novel miRNAs predicted by miRDeep2
+provisional id	miRDeep2 score	estimated probability that the miRNA candidate is a true positive	rfam alert	total read count	mature read count	loop read count	star read count	significant randfold p-value	miRBase miRNA	example miRBase miRNA with the same seed	UCSC browser	NCBI blastn	consensus mature sequence	consensus star sequence	consensus precursor sequence	precursor coordinate
+NC_007424.3_29324	114.2	83 +/- 12%	-	221	200	0	21	yes	-	-	-	-	cuccucgcugguagauggcgggcu	ccgccaugaccggcggggcggcg	ccgccaugaccggcggggcggcgcggcucgaguugugcuccucgcugguagauggcgggcu	NC_007424.3:13942158..13942219:-
+NC_007417.3_5178	328.3	83 +/- 12%	-	649	532	0	117	yes	-	-	-	-	cuucaacucacuuuggacaacu	uuguccaacuugaguauugaga	uuguccaacuugaguauugagaacggaauuaaucucgcucuucaacucacuuuggacaacu	NC_007417.3:14308626..14308687:-
+NC_007424.3_28086	89.7	83 +/- 12%	-	175	50	0	125	yes	-	-	-	-	cggucaguaagucugcugaugcu	uuucagcucucuuacuuuccguc	cggucaguaagucugcugaugcuuuuacgacaguuucagcucucuuacuuuccguc	NC_007424.3:14276628..14276684:+
+NC_007417.3_2806	45.1	83 +/- 12%	-	94	93	0	1	yes	-	hsa-miR-5582-3p	-	-	cauucagaaguauuaauucgga	uaaaacuucacgaacug	uaaaacuucacgaacugucacguaccaugauuucaauucacuucaauuagcgacguuacauucagaaguauuaauucgga	NC_007417.3:5866105..5866185:+
+NW_015452101.1_46214	0.4	56 +/- 9%	-	4140	4138	2	0	no	-	gga-miR-1774	-	-	ucccugcucgggcgcca	gcuuugucggagaucggguug	ucccugcucgggcgccaaaauuuguaauguccuuuuuccgggcggcuuugucggagaucggguug	NW_015452101.1:671..736:+
+NC_007424.3_28116	0.3	56 +/- 9%	-	3	3	0	0	yes	-	sma-miR-8462-5p	-	-	ugauuaaucuuuacuguuacc	caaccauagagauuaaucaag	ugauuaaucuuuacuguuaccauaguuacagcauggcaaccauagagauuaaucaag	NC_007424.3:15097848..15097905:+
+NC_007419.2_12804	0.3	56 +/- 9%	-	408	407	1	0	no	-	bfl-miR-4892	-	-	guaggauaagugggagu	acuuccugccugcga	acuuccugccugcgauugggcuuuauuuaacugaguuaaaguguaggauaagugggagu	NC_007419.2:9640109..9640168:-
+NC_007425.3_29801	0.2	56 +/- 9%	-	18911	18911	0	0	yes	-	-	-	-	guucccggaccacuccc	ucguauuccgguggcaa	ucguauuccgguggcaacuuaaugauauuuugugacguucauuaagugaguuuguucccggaccacuccc	NC_007425.3:2845289..2845359:+
+NC_007419.2_12773	0	56 +/- 9%	-	4	4	0	0	yes	-	ame-miR-3790-5p	-	-	aaaagcgacuuuuuucuugcug	gcagguaaaaaaguaauuuuggc	aaaagcgacuuuuuucuugcuguuggaauaauuggcagguaaaaaaguaauuuuggc	NC_007419.2:9213500..9213557:-
+
+
+
+mature miRBase miRNAs detected by miRDeep2
+tag id	miRDeep2 score	estimated probability that the miRNA is a true positive	rfam alert	total read count	mature read count	loop read count	star read count	significant randfold p-value	mature miRBase miRNA	example miRBase miRNA with the same seed	UCSC browser	NCBI blastn	consensus mature sequence	consensus star sequence	consensus precursor sequence	precursor coordinate
+NC_007424.3_28946	1080044	83 +/- 12%	-	2118452	2095855	0	22597	yes	tca-miR-8-5p	sha-miR-200c	-	-	uaauacugucagguaaagauguc	caucuuaccgggcagcauuaga	caucuuaccgggcagcauuagauuacauuuuauacuucuaauacugucagguaaagauguc	NC_007424.3:8781912..8781973:-
+NC_007417.3_2952	960398.2	83 +/- 12%	-	1883771	1870384	0	13387	yes	tca-miR-10-5p	cpi-miR-10b-5p	-	-	uacccuguagauccgaauuugu	caaauucgguucuagagagguuu	uacccuguagauccgaauuuguuugaaaucaggcgacaaauucgguucuagagagguuu	NC_007417.3:8460382..8460441:+
+NC_007422.5_18806	699490.5	83 +/- 12%	-	1372012	1371975	0	37	yes	tca-miR-31-5p	bma-miR-72	-	-	aggcaagaugucggcauagcuga	ggcuaugucucauccggccaac	aggcaagaugucggcauagcugaagguguuugaaacggcuaugucucauccggccaac	NC_007422.5:5938428..5938486:+
+NC_007418.3_6733	364433.7	83 +/- 12%	-	714813	714478	0	335	yes	tca-bantam-5p	hpo-miR-10021-5p	-	-	ugagaucauugugaaagcugauu	cugguuuucacagugauuugac	cugguuuucacagugauuugacagauauauuugauucugagaucauugugaaagcugauu	NC_007418.3:16990365..16990425:+
+NC_007418.3_8508	298016.6	83 +/- 12%	-	584538	583631	0	907	yes	tca-miR-276-5p	der-miR-276a	-	-	uaggaacuucauaccgugcucu	agcgagguauagaguuccuacg	agcgagguauagaguuccuacgugauuuuucggcuguaggaacuucauaccgugcucu	NC_007418.3:12483937..12483995:-
+NC_007418.3_6695	280475.2	83 +/- 12%	-	550133	549894	1	238	yes	tca-miR-279c-5p	dme-miR-279-3p	-	-	ugacuagaucgaacauucgcu	cggguguucguuucgagucaca	cggguguucguuucgagucacauugugauugauuuugugacuagaucgaacauucgcu	NC_007418.3:15690068..15690126:+
+NC_007420.3_15639	260138.4	83 +/- 12%	-	510241	509166	0	1075	yes	tca-miR-263a-5p	ggo-miR-183	-	-	aauggcacuggaagaauucacggg	cguggacuuugagugccauccu	aauggcacuggaagaauucacgggguucuucgcacucccguggacuuugagugccauccu	NC_007420.3:13500412..13500472:-
+NC_007422.5_18118	225456.2	83 +/- 12%	-	442214	408799	0	33415	yes	tca-miR-281-5p	sma-miR-281-5p	-	-	aagagagcuauccgucgacagu	cugucauggaguugcucucuu	aagagagcuauccgucgacaguauauaauuuacacugucauggaguugcucucuu	NC_007422.5:203927..203982:+
+NC_007421.3_16306	196235.3	83 +/- 12%	-	384898	384031	0	867	yes	tca-miR-100-5p	cbn-miR-52	-	-	aacccguagauccgaacuugug	caaguucuuguuuauggguacc	aacccguagauccgaacuuguggggcuguggucacaaguucuuguuuauggguacc	NC_007421.3:4363293..4363349:+
+NC_007422.5_19503	155861.3	83 +/- 12%	-	305707	304852	0	855	yes	tca-miR-184-5p	cin-miR-184	-	-	uggacggagaacugauaagggc	ccuugucauucucucgcccggu	ccuugucauucucucgcccgguguauuuuaacaacuggacggagaacugauaagggc	NC_007422.5:12944303..12944360:+
+NC_007418.3_5615	136501.5	83 +/- 12%	-	267736	256940	0	10796	yes	tca-miR-14-5p	bmo-miR-3368	-	-	ucagucuuuuucucucuccuau	aggggagcggauuggacuuacu	aggggagcggauuggacuuacuuuuuuucaaacagucagucuuuuucucucuccuau	NC_007418.3:2833775..2833832:+
+NC_007416.3_1577	112414	83 +/- 12%	-	220488	217173	2	3313	yes	tca-miR-9a-5p	dse-miR-9b	-	-	ucuuugguuaucuagcuguauga	uaaagcuagguuaccggaguua	ucuuugguuaucuagcuguaugaguauuguuuaauaacaucauaaagcuagguuaccggaguua	NC_007416.3:6011260..6011324:-
+NC_007418.3_5397	99158.8	83 +/- 12%	-	194487	194476	0	11	yes	tca-miR-2-2-5p	gsa-miR-2c-3p	-	-	ucacagccagcuuugaugag	ucaucaucugguugugaaaug	ucaucaucugguugugaaaugugaauuuauaucauaucacagccagcuuugaugag	NC_007418.3:561351..561407:+
+
+#miRBase miRNAs not detected by miRDeep2
+miRBase precursor id	total read count	5p read counts	3p read counts	remaining reads	UCSC browser	NCBI blastn	miRBase 5p sequence(s)	miRBase 3p sequence(s)	miRBase precursor sequence
+53558	52520	434	604	-	-	ucccugagacccuaacuuguga	acaagcuagcgacucggguauug	auuugccuauucccugagacccuaacuugugauguuaaauggacucucacaagcuagcgacucggguauuggcggau	
+14158	281	13867	10	-	-	cgugcgaucuuuccauuccuacuug	uaguacggaauuaucucac	cucuuuucgcauuaucuuucgugcgaucuuuccauuccuacuuguuguuugauaaguaguacggaauuaucucacauuagauauugggaguuuuc	
+12365	12194	170	1	-	-	ucuuuggugaucuaguuguau	auaaagcugguucagcaaagca	aacagguugcaagucggauauauucuucuuuggugaucuaguuguaugaguguuuuauauaucauaaagcugguucagcaaagcagauugcauucgacucuucgacgagcc	
+2841	2763	14	64	-	-	acugaagcugacgaguuaacugccgg	ucccggauuuuuuccccagccucaa	aaaacugaagcugacgaguuaacugccggguacuuguucccggauuuuuuccccagccucaagaag	
+2846	2415	27	404	-	-	acccaucuucagacaacucugg	cgaguuugcuuuugaugggaga	aguguaggcgauuuugacccaucuucagacaacucuggauuguuuuaaauguccacgaguuugcuuuugaugggagaucaauagucuuuuag	
+2594	2256	1	337	-	-	ugauguuauuuucgaccucc	ucucugguagaaaguacgucau	ggauggaaugauguuauuuucgaccuccaccacccucucugguagaaaguacgucauucaccuc	
+2074	395	1677	2	-	-	cgcaggauuugcuugugaaugg	aaucacaggaaaauucugugcg	ucaaaugggguaauuggcgcccugcgcaggauuugcuugugaaugggugugcuugauucaaucacaggaaaauucugugcggggaguugguuuugucaccaca	
+848	0	848	0	-	-	uggguuauugugugccggu	aaccggccauaaagcccuc	caauuggguuauugugugccggucauuacaucauuacaggucauguaaaccggccauaaagcccucaac	
+1797	792	449	556	-	-	ugccacugaugaauuacugcuagaau	uugaggauucgcaguuucugaggcaa	uaaaaucuuguugccacugaugaauuacugcuagaaucuuccuuuaauuuaaguugaggauucgcaguuucugaggcaaauuagaaaa	
+806	79	725	2	-	-	aggggguacuguaaguacgua	uaguacgaacgguacucacuau	caucagugaaugcuuuguaggggguacuguaaguacguacgauuuuuuuaacguaguacgaacgguacucacuaugaacguuacacaguuu	

--- a/t/MINING_curate_mirdeep2fasta_collision.dat
+++ b/t/MINING_curate_mirdeep2fasta_collision.dat
@@ -1,0 +1,68 @@
+miRDeep2 score	novel miRNAs reported by miRDeep2	novel miRNAs, estimated false positives	novel miRNAs, estimated true positives	known miRNAs in species	known miRNAs in data	known miRNAs detected by miRDeep2	estimated signal-to-noise	excision gearing
+10	10	2 +/- 1	8 +/- 1 (83 +/- 12%)	590	427	254 (59%)	38.2	3
+9	10	2 +/- 1	8 +/- 1 (82 +/- 13%)	590	427	256 (60%)	37.8	3
+8	10	2 +/- 1	8 +/- 1 (82 +/- 14%)	590	427	258 (60%)	37	3
+7	10	2 +/- 1	8 +/- 1 (81 +/- 14%)	590	427	258 (60%)	36.4	3
+6	11	2 +/- 1	9 +/- 1 (82 +/- 13%)	590	427	260 (61%)	36.2	3
+5	18	2 +/- 2	16 +/- 2 (88 +/- 8%)	590	427	300 (70%)	37.6	3
+4	27	3 +/- 2	24 +/- 2 (90 +/- 6%)	590	427	329 (77%)	31.4	3
+3	32	7 +/- 3	25 +/- 3 (78 +/- 8%)	590	427	338 (79%)	16.9	3
+2	37	12 +/- 3	25 +/- 3 (68 +/- 9%)	590	427	340 (80%)	11.7	3
+1	44	17 +/- 4	27 +/- 4 (61 +/- 10%)	590	427	347 (81%)	8.9	3
+0	53	23 +/- 5	30 +/- 5 (56 +/- 9%)	590	427	349 (82%)	7.2	3
+-1	57	31 +/- 5	26 +/- 5 (45 +/- 9%)	590	427	351 (82%)	5.7	3
+-2	66	40 +/- 6	26 +/- 6 (40 +/- 9%)	590	427	351 (82%)	4.8	3
+-3	73	48 +/- 7	25 +/- 7 (34 +/- 9%)	590	427	352 (82%)	4.2	3
+-4	81	55 +/- 7	26 +/- 7 (32 +/- 9%)	590	427	352 (82%)	3.8	3
+-5	85	63 +/- 7	22 +/- 7 (26 +/- 8%)	590	427	352 (82%)	3.5	3
+-6	87	70 +/- 8	17 +/- 8 (20 +/- 9%)	590	427	352 (82%)	3.2	3
+-7	93	75 +/- 8	18 +/- 8 (19 +/- 8%)	590	427	352 (82%)	3.1	3
+-8	95	81 +/- 8	14 +/- 8 (15 +/- 8%)	590	427	352 (82%)	2.9	3
+-9	100	85 +/- 8	15 +/- 8 (15 +/- 8%)	590	427	352 (82%)	2.9	3
+-10	103	89 +/- 8	14 +/- 8 (14 +/- 8%)	590	427	352 (82%)	2.8	3
+
+
+
+novel miRNAs predicted by miRDeep2
+provisional id	miRDeep2 score	estimated probability that the miRNA candidate is a true positive	rfam alert	total read count	mature read count	loop read count	star read count	significant randfold p-value	miRBase miRNA	example miRBase miRNA with the same seed	UCSC browser	NCBI blastn	consensus mature sequence	consensus star sequence	consensus precursor sequence	precursor coordinate
+NC_007417.3_5178	328.3	83 +/- 12%	-	649	532	0	117	yes	-	-	-	-	cuucaacucacuuuggacaacu	uuguccaacuugaguauugaga	uuguccaacuugaguauugagaacggaauuaaucucgcucuucaacucacuuuggacaacu	NC_007417.3:14308626..14308687:-
+NC_007417.3_5178	328.3	83 +/- 12%	-	649	532	0	117	yes	-	-	-	-	cuucaacucacuuuggacaacu	uuguccaacuugaguauugaga	uuguccaacuugaguauugagaacggaauuaaucucgcucuucaacucacuuuggacaacu	NC_007417.3:14308626..14308687:-
+NC_007424.3_29324	114.2	83 +/- 12%	-	221	200	0	21	yes	-	-	-	-	cuccucgcugguagauggcgggcu	ccgccaugaccggcggggcggcg	ccgccaugaccggcggggcggcgcggcucgaguugugcuccucgcugguagauggcgggcu	NC_007424.3:13942158..13942219:-
+NC_007424.3_28086	89.7	83 +/- 12%	-	175	50	0	125	yes	-	-	-	-	cggucaguaagucugcugaugcu	uuucagcucucuuacuuuccguc	cggucaguaagucugcugaugcuuuuacgacaguuucagcucucuuacuuuccguc	NC_007424.3:14276628..14276684:+
+NC_007417.3_2806	45.1	83 +/- 12%	-	94	93	0	1	yes	-	hsa-miR-5582-3p	-	-	uaaaacuucacgaacug	cauucagaaguauuaauucgga	uaaaacuucacgaacugucacguaccaugauuucaauucacuucaauuagcgacguuacauucagaaguauuaauucgga	NC_007417.3:5866105..5866185:+
+NW_015452101.1_46214	0.4	56 +/- 9%	-	4140	4138	2	0	no	-	gga-miR-1774	-	-	ucccugcucgggcgcca	gcuuugucggagaucggguug	ucccugcucgggcgccaaaauuuguaauguccuuuuuccgggcggcuuugucggagaucggguug	NW_015452101.1:671..736:+
+NC_007424.3_28116	0.3	56 +/- 9%	-	3	3	0	0	yes	-	sma-miR-8462-5p	-	-	ugauuaaucuuuacuguuacc	caaccauagagauuaaucaag	ugauuaaucuuuacuguuaccauaguuacagcauggcaaccauagagauuaaucaag	NC_007424.3:15097848..15097905:+
+NC_007419.2_12804	0.3	56 +/- 9%	-	408	407	1	0	no	-	bfl-miR-4892	-	-	guaggauaagugggagu	acuuccugccugcga	acuuccugccugcgauugggcuuuauuuaacugaguuaaaguguaggauaagugggagu	NC_007419.2:9640109..9640168:-
+NC_007425.3_29801	0.2	56 +/- 9%	-	18911	18911	0	0	yes	-	-	-	-	guucccggaccacuccc	ucguauuccgguggcaa	ucguauuccgguggcaacuuaaugauauuuugugacguucauuaagugaguuuguucccggaccacuccc	NC_007425.3:2845289..2845359:+
+NC_007419.2_12773	0	56 +/- 9%	-	4	4	0	0	yes	-	ame-miR-3790-5p	-	-	aaaagcgacuuuuuucuugcug	gcagguaaaaaaguaauuuuggc	aaaagcgacuuuuuucuugcuguuggaauaauuggcagguaaaaaaguaauuuuggc	NC_007419.2:9213500..9213557:-
+
+
+
+mature miRBase miRNAs detected by miRDeep2
+tag id	miRDeep2 score	estimated probability that the miRNA is a true positive	rfam alert	total read count	mature read count	loop read count	star read count	significant randfold p-value	mature miRBase miRNA	example miRBase miRNA with the same seed	UCSC browser	NCBI blastn	consensus mature sequence	consensus star sequence	consensus precursor sequence	precursor coordinate
+NC_007424.3_28946	1080044	83 +/- 12%	-	2118452	2095855	0	22597	yes	tca-miR-8-5p	sha-miR-200c	-	-	uaauacugucagguaaagauguc	caucuuaccgggcagcauuaga	caucuuaccgggcagcauuagauuacauuuuauacuucuaauacugucagguaaagauguc	NC_007424.3:8781912..8781973:-
+NC_007417.3_2952	960398.2	83 +/- 12%	-	1883771	1870384	0	13387	yes	tca-miR-10-5p	cpi-miR-10b-5p	-	-	uacccuguagauccgaauuugu	caaauucgguucuagagagguuu	uacccuguagauccgaauuuguuugaaaucaggcgacaaauucgguucuagagagguuu	NC_007417.3:8460382..8460441:+
+NC_007422.5_18806	699490.5	83 +/- 12%	-	1372012	1371975	0	37	yes	tca-miR-31-5p	bma-miR-72	-	-	aggcaagaugucggcauagcuga	ggcuaugucucauccggccaac	aggcaagaugucggcauagcugaagguguuugaaacggcuaugucucauccggccaac	NC_007422.5:5938428..5938486:+
+NC_007418.3_6733	364433.7	83 +/- 12%	-	714813	714478	0	335	yes	tca-bantam-5p	hpo-miR-10021-5p	-	-	ugagaucauugugaaagcugauu	cugguuuucacagugauuugac	cugguuuucacagugauuugacagauauauuugauucugagaucauugugaaagcugauu	NC_007418.3:16990365..16990425:+
+NC_007418.3_8508	298016.6	83 +/- 12%	-	584538	583631	0	907	yes	tca-miR-276-5p	der-miR-276a	-	-	uaggaacuucauaccgugcucu	agcgagguauagaguuccuacg	agcgagguauagaguuccuacgugauuuuucggcuguaggaacuucauaccgugcucu	NC_007418.3:12483937..12483995:-
+NC_007418.3_6695	280475.2	83 +/- 12%	-	550133	549894	1	238	yes	tca-miR-279c-5p	dme-miR-279-3p	-	-	ugacuagaucgaacauucgcu	cggguguucguuucgagucaca	cggguguucguuucgagucacauugugauugauuuugugacuagaucgaacauucgcu	NC_007418.3:15690068..15690126:+
+NC_007420.3_15639	260138.4	83 +/- 12%	-	510241	509166	0	1075	yes	tca-miR-263a-5p	ggo-miR-183	-	-	aauggcacuggaagaauucacggg	cguggacuuugagugccauccu	aauggcacuggaagaauucacgggguucuucgcacucccguggacuuugagugccauccu	NC_007420.3:13500412..13500472:-
+NC_007422.5_18118	225456.2	83 +/- 12%	-	442214	408799	0	33415	yes	tca-miR-281-5p	sma-miR-281-5p	-	-	aagagagcuauccgucgacagu	cugucauggaguugcucucuu	aagagagcuauccgucgacaguauauaauuuacacugucauggaguugcucucuu	NC_007422.5:203927..203982:+
+NC_007421.3_16306	196235.3	83 +/- 12%	-	384898	384031	0	867	yes	tca-miR-100-5p	cbn-miR-52	-	-	aacccguagauccgaacuugug	caaguucuuguuuauggguacc	aacccguagauccgaacuuguggggcuguggucacaaguucuuguuuauggguacc	NC_007421.3:4363293..4363349:+
+NC_007422.5_19503	155861.3	83 +/- 12%	-	305707	304852	0	855	yes	tca-miR-184-5p	cin-miR-184	-	-	uggacggagaacugauaagggc	ccuugucauucucucgcccggu	ccuugucauucucucgcccgguguauuuuaacaacuggacggagaacugauaagggc	NC_007422.5:12944303..12944360:+
+NC_007418.3_5615	136501.5	83 +/- 12%	-	267736	256940	0	10796	yes	tca-miR-14-5p	bmo-miR-3368	-	-	ucagucuuuuucucucuccuau	aggggagcggauuggacuuacu	aggggagcggauuggacuuacuuuuuuucaaacagucagucuuuuucucucuccuau	NC_007418.3:2833775..2833832:+
+NC_007416.3_1577	112414	83 +/- 12%	-	220488	217173	2	3313	yes	tca-miR-9a-5p	dse-miR-9b	-	-	ucuuugguuaucuagcuguauga	uaaagcuagguuaccggaguua	ucuuugguuaucuagcuguaugaguauuguuuaauaacaucauaaagcuagguuaccggaguua	NC_007416.3:6011260..6011324:-
+NC_007418.3_5397	99158.8	83 +/- 12%	-	194487	194476	0	11	yes	tca-miR-2-2-5p	gsa-miR-2c-3p	-	-	ucacagccagcuuugaugag	ucaucaucugguugugaaaug	ucaucaucugguugugaaaugugaauuuauaucauaucacagccagcuuugaugag	NC_007418.3:561351..561407:+
+
+#miRBase miRNAs not detected by miRDeep2
+miRBase precursor id	total read count	5p read counts	3p read counts	remaining reads	UCSC browser	NCBI blastn	miRBase 5p sequence(s)	miRBase 3p sequence(s)	miRBase precursor sequence
+53558	52520	434	604	-	-	ucccugagacccuaacuuguga	acaagcuagcgacucggguauug	auuugccuauucccugagacccuaacuugugauguuaaauggacucucacaagcuagcgacucggguauuggcggau	
+14158	281	13867	10	-	-	cgugcgaucuuuccauuccuacuug	uaguacggaauuaucucac	cucuuuucgcauuaucuuucgugcgaucuuuccauuccuacuuguuguuugauaaguaguacggaauuaucucacauuagauauugggaguuuuc	
+12365	12194	170	1	-	-	ucuuuggugaucuaguuguau	auaaagcugguucagcaaagca	aacagguugcaagucggauauauucuucuuuggugaucuaguuguaugaguguuuuauauaucauaaagcugguucagcaaagcagauugcauucgacucuucgacgagcc	
+2841	2763	14	64	-	-	acugaagcugacgaguuaacugccgg	ucccggauuuuuuccccagccucaa	aaaacugaagcugacgaguuaacugccggguacuuguucccggauuuuuuccccagccucaagaag	
+2846	2415	27	404	-	-	acccaucuucagacaacucugg	cgaguuugcuuuugaugggaga	aguguaggcgauuuugacccaucuucagacaacucuggauuguuuuaaauguccacgaguuugcuuuugaugggagaucaauagucuuuuag	
+2594	2256	1	337	-	-	ugauguuauuuucgaccucc	ucucugguagaaaguacgucau	ggauggaaugauguuauuuucgaccuccaccacccucucugguagaaaguacgucauucaccuc	
+2074	395	1677	2	-	-	cgcaggauuugcuugugaaugg	aaucacaggaaaauucugugcg	ucaaaugggguaauuggcgcccugcgcaggauuugcuugugaaugggugugcuugauucaaucacaggaaaauucugugcggggaguugguuuugucaccaca	
+848	0	848	0	-	-	uggguuauugugugccggu	aaccggccauaaagcccuc	caauuggguuauugugugccggucauuacaucauuacaggucauguaaaccggccauaaagcccucaac	
+1797	792	449	556	-	-	ugccacugaugaauuacugcuagaau	uugaggauucgcaguuucugaggcaa	uaaaaucuuguugccacugaugaauuacugcuagaaucuuccuuuaauuuaaguugaggauucgcaguuucugaggcaaauuagaaaa	
+806	79	725	2	-	-	aggggguacuguaaguacgua	uaguacgaacgguacucacuau	caucagugaaugcuuuguaggggguacuguaaguacguacgauuuuuuuaacguaguacgaacgguacucacuaugaacguuacacaguuu	


### PR DESCRIPTION
Fixes # 101.

Changes proposed within this pull request
- stabil naming of new miRNAs based on hairpin, mature5p, and mature3p sequence
- number correspondes to lowes 16 bit of MD5
- collisions are detected and cause exception

@microPIECE-team/micropiece-team-admins
