### PR TITLE
Pseudo mirbase dat will be copied into output folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,14 @@ docker run -it --rm -v $PWD:/data micropiece/micropiece:v1.3.0 microPIECE.pl   \
 
 ### OUTPUT
 
+- pseudo mirBASE dat file: `final_mirbase_pseudofile.dat`
+
+    A pseudo mirBASE dat file containing all precursor sequences with their named mature sequences and their coordinates. It only contain the fields:
+
+    - `ID`
+    - `FH` and `FT`
+    - `SQ`
+
 - mature miRNA set: `mature_combined_mirbase_novel.fa`
 
     mature microRNA set, containing novels and miRBase-completed (if mined), together with the known miRNAs from miRBase

--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ Please report any new issues ad [new Github-Issue](https://github.com/microPIECE
 ## Changelog
 - scheduled for next release
 
+    Copying pseudo mirBASE dat file `final_mirbase_pseudofile.dat` into output folder (Fixes [#131](https://github.com/microPIECE-team/microPIECE/issues/131))
+
     Corrected `RNA::HairpinFigure` output (Fixes [#137](https://github.com/microPIECE-team/microPIECE/issues/137))
 
     Fix the requirement of an accession inside mirBASE dat file (Fixes [#134](https://github.com/microPIECE-team/microPIECE/issues/134))

--- a/lib/microPIECE.pm
+++ b/lib/microPIECE.pm
@@ -1508,6 +1508,11 @@ sub transfer_resultfiles
 
     $L->info("Start copying result files into output folder");
 
+    # pseudo mirBASE dat file
+    # final_mirbase_pseudofile.dat :=
+    # A pseudo mirBASE dat file containing all precursor sequences with their named mature sequences and their coordinates.
+    copy_final_files($opt, $opt->{mining}{completion}{dat});
+
     # mature miRNA set
     # mature_combined_mirbase_novel.fa :=
     # mature microRNA set, containing novels and miRBase-completed (if mined), together with the known miRNAs from miRBase

--- a/microPIECE.pl
+++ b/microPIECE.pl
@@ -267,6 +267,20 @@ Sets the F<Piranha> bin size and has a default value of C<20>.
 
 =over 4
 
+=item pseudo mirBASE dat file: F<final_mirbase_pseudofile.dat>
+
+A pseudo mirBASE dat file containing all precursor sequences with their named mature sequences and their coordinates. It only contain the fields:
+
+=over 4
+
+=item C<ID>
+
+=item C<FH> and C<FT>
+
+=item C<SQ>
+
+=back
+
 =item mature miRNA set: F<mature_combined_mirbase_novel.fa>
 
 mature microRNA set, containing novels and miRBase-completed (if mined), together with the known miRNAs from miRBase

--- a/microPIECE.pl
+++ b/microPIECE.pl
@@ -431,6 +431,8 @@ Please report any new issues ad L<new Github-Issue|https://github.com/microPIECE
 
 =item scheduled for next release
 
+Copying pseudo mirBASE dat file C<final_mirbase_pseudofile.dat> into output folder (Fixes L<#131|https://github.com/microPIECE-team/microPIECE/issues/131>)
+
 Corrected C<RNA::HairpinFigure> output (Fixes L<#137|https://github.com/microPIECE-team/microPIECE/issues/137>)
 
 Fix the requirement of an accession inside mirBASE dat file (Fixes L<#134|https://github.com/microPIECE-team/microPIECE/issues/134>)


### PR DESCRIPTION
Fixes #131  .

Changes proposed within this pull request
- Finally, pseudo mirBASE dat file will be copied into output folder

@microPIECE-team/micropiece-team-admins
