### PR TITLE
Bump to Release v1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Please report any new issues ad [new Github-Issue](https://github.com/microPIECE
 ## Changelog
 - scheduled for next release
 
-    No features
+    Avoiding error message while copying the out file for genomic location into base folder (Fixes [#117](https://github.com/microPIECE-team/microPIECE/issues/117)) 
 
 - [v1.3.0](https://github.com/microPIECE-team/microPIECE/releases/tag/v1.3.0) (2018-03-29)
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,14 @@ docker run -it --rm -v $PWD:/data micropiece/micropiece:v1.3.0 microPIECE.pl   \
 
 ### OUTPUT
 
+- pseudo mirBASE dat file: `final_mirbase_pseudofile.dat`
+
+    A pseudo mirBASE dat file containing all precursor sequences with their named mature sequences and their coordinates. It only contain the fields:
+
+    - `ID`
+    - `FH` and `FT`
+    - `SQ`
+
 - mature miRNA set: `mature_combined_mirbase_novel.fa`
 
     mature microRNA set, containing novels and miRBase-completed (if mined), together with the known miRNAs from miRBase
@@ -282,6 +290,8 @@ Please report any new issues ad [new Github-Issue](https://github.com/microPIECE
 
 ## Changelog
 - scheduled for next release
+
+    Copying pseudo mirBASE dat file `final_mirbase_pseudofile.dat` into output folder (Fixes [#131](https://github.com/microPIECE-team/microPIECE/issues/131))
 
     Corrected `RNA::HairpinFigure` output (Fixes [#137](https://github.com/microPIECE-team/microPIECE/issues/137))
 

--- a/README.md
+++ b/README.md
@@ -291,6 +291,10 @@ Please report any new issues ad [new Github-Issue](https://github.com/microPIECE
 ## Changelog
 - scheduled for next release
 
+    No features planed
+
+- [v1.4.0](https://github.com/microPIECE-team/microPIECE/releases/tag/v1.4.0) (2018-03-31)
+
     Copying pseudo mirBASE dat file `final_mirbase_pseudofile.dat` into output folder (Fixes [#131](https://github.com/microPIECE-team/microPIECE/issues/131))
 
     Corrected `RNA::HairpinFigure` output (Fixes [#137](https://github.com/microPIECE-team/microPIECE/issues/137))

--- a/README.md
+++ b/README.md
@@ -283,6 +283,8 @@ Please report any new issues ad [new Github-Issue](https://github.com/microPIECE
 ## Changelog
 - scheduled for next release
 
+    Corrected `RNA::HairpinFigure` output (Fixes [#137](https://github.com/microPIECE-team/microPIECE/issues/137))
+
     Avoiding error message while copying the out file for genomic location into base folder (Fixes [#117](https://github.com/microPIECE-team/microPIECE/issues/117)) 
 
 - [v1.3.0](https://github.com/microPIECE-team/microPIECE/releases/tag/v1.3.0) (2018-03-29)

--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ Please report any new issues ad [new Github-Issue](https://github.com/microPIECE
 
     Corrected `RNA::HairpinFigure` output (Fixes [#137](https://github.com/microPIECE-team/microPIECE/issues/137))
 
+    Fix the requirement of an accession inside mirBASE dat file (Fixes [#134](https://github.com/microPIECE-team/microPIECE/issues/134))
+
     Avoiding error message while copying the out file for genomic location into base folder (Fixes [#117](https://github.com/microPIECE-team/microPIECE/issues/117)) 
 
 - [v1.3.0](https://github.com/microPIECE-team/microPIECE/releases/tag/v1.3.0) (2018-03-29)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN echo "VCS_REF: "${VCS_REF}", BUILD_DATE: "${BUILD_DATE}", micropiece_version
 
 LABEL maintainer="frank.foerster@ime.fraunhofer.de" \
       description="Container for the microPIECE package" \
-      version="1.2.2" \
+      version="1.4.0" \
       org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.vcs-url="https://github.com/microPIECE-team/microPIECE"

--- a/lib/microPIECE.pm
+++ b/lib/microPIECE.pm
@@ -3,7 +3,7 @@ package microPIECE;
 use strict;
 use warnings;
 
-use version 0.77; our $VERSION = version->declare("v1.3.0");
+use version 0.77; our $VERSION = version->declare("v1.4.0");
 
 use Log::Log4perl;
 use Data::Dumper;

--- a/lib/microPIECE.pm
+++ b/lib/microPIECE.pm
@@ -1508,6 +1508,11 @@ sub transfer_resultfiles
 
     $L->info("Start copying result files into output folder");
 
+    # pseudo mirBASE dat file
+    # final_mirbase_pseudofile.dat :=
+    # A pseudo mirBASE dat file containing all precursor sequences with their named mature sequences and their coordinates.
+    copy_final_files($opt, $opt->{mining}{completion}{dat});
+
     # mature miRNA set
     # mature_combined_mirbase_novel.fa :=
     # mature microRNA set, containing novels and miRBase-completed (if mined), together with the known miRNAs from miRBase

--- a/lib/microPIECE.pm
+++ b/lib/microPIECE.pm
@@ -653,7 +653,7 @@ sub run_mining_genomicposition
     my $blastoutput = run_cmd($L, \@cmd);
 
     # filter the hits and store them
-    $opt->{mining}{genomic_location} = "miRNA_genomic_position.csv";
+    $opt->{mining}{genomic_location} = getcwd()."/"."miRNA_genomic_position.csv";
     open(FH, ">", $opt->{mining}{genomic_location}) || $L->logdie("Unable to open file '$opt->{mining}{genomic_location}': $!");
     foreach my $line (split(/\n/, $blastoutput))
     {

--- a/microPIECE.pl
+++ b/microPIECE.pl
@@ -267,6 +267,20 @@ Sets the F<Piranha> bin size and has a default value of C<20>.
 
 =over 4
 
+=item pseudo mirBASE dat file: F<final_mirbase_pseudofile.dat>
+
+A pseudo mirBASE dat file containing all precursor sequences with their named mature sequences and their coordinates. It only contain the fields:
+
+=over 4
+
+=item C<ID>
+
+=item C<FH> and C<FT>
+
+=item C<SQ>
+
+=back
+
 =item mature miRNA set: F<mature_combined_mirbase_novel.fa>
 
 mature microRNA set, containing novels and miRBase-completed (if mined), together with the known miRNAs from miRBase
@@ -416,6 +430,8 @@ Please report any new issues ad L<new Github-Issue|https://github.com/microPIECE
 =over 4
 
 =item scheduled for next release
+
+Copying pseudo mirBASE dat file C<final_mirbase_pseudofile.dat> into output folder (Fixes L<#131|https://github.com/microPIECE-team/microPIECE/issues/131>)
 
 Corrected C<RNA::HairpinFigure> output (Fixes L<#137|https://github.com/microPIECE-team/microPIECE/issues/137>)
 

--- a/microPIECE.pl
+++ b/microPIECE.pl
@@ -431,6 +431,10 @@ Please report any new issues ad L<new Github-Issue|https://github.com/microPIECE
 
 =item scheduled for next release
 
+No features planed
+
+=item L<v1.4.0|https://github.com/microPIECE-team/microPIECE/releases/tag/v1.4.0> (2018-03-31)
+
 Copying pseudo mirBASE dat file C<final_mirbase_pseudofile.dat> into output folder (Fixes L<#131|https://github.com/microPIECE-team/microPIECE/issues/131>)
 
 Corrected C<RNA::HairpinFigure> output (Fixes L<#137|https://github.com/microPIECE-team/microPIECE/issues/137>)

--- a/microPIECE.pl
+++ b/microPIECE.pl
@@ -419,6 +419,8 @@ Please report any new issues ad L<new Github-Issue|https://github.com/microPIECE
 
 Corrected C<RNA::HairpinFigure> output (Fixes L<#137|https://github.com/microPIECE-team/microPIECE/issues/137>)
 
+Fix the requirement of an accession inside mirBASE dat file (Fixes L<#134|https://github.com/microPIECE-team/microPIECE/issues/134>)
+
 Avoiding error message while copying the out file for genomic location into base folder (Fixes L<#117|https://github.com/microPIECE-team/microPIECE/issues/117>)
 
 =item L<v1.3.0|https://github.com/microPIECE-team/microPIECE/releases/tag/v1.3.0> (2018-03-29)

--- a/microPIECE.pl
+++ b/microPIECE.pl
@@ -417,6 +417,8 @@ Please report any new issues ad L<new Github-Issue|https://github.com/microPIECE
 
 =item scheduled for next release
 
+Corrected C<RNA::HairpinFigure> output (Fixes L<#137|https://github.com/microPIECE-team/microPIECE/issues/137>)
+
 Avoiding error message while copying the out file for genomic location into base folder (Fixes L<#117|https://github.com/microPIECE-team/microPIECE/issues/117>)
 
 =item L<v1.3.0|https://github.com/microPIECE-team/microPIECE/releases/tag/v1.3.0> (2018-03-29)

--- a/microPIECE.pl
+++ b/microPIECE.pl
@@ -417,7 +417,7 @@ Please report any new issues ad L<new Github-Issue|https://github.com/microPIECE
 
 =item scheduled for next release
 
-No features planed
+Avoiding error message while copying the out file for genomic location into base folder (Fixes L<#117|https://github.com/microPIECE-team/microPIECE/issues/117>)
 
 =item L<v1.3.0|https://github.com/microPIECE-team/microPIECE/releases/tag/v1.3.0> (2018-03-29)
 

--- a/scripts/ISOMIR_create_mirbase_struct.pl
+++ b/scripts/ISOMIR_create_mirbase_struct.pl
@@ -76,7 +76,7 @@ foreach my $entry (@{$mirnas})
     }
 
     printf OUT ">%s %s %s\n\n", $entry->{precursor}, $energy, join(" ", @mature_infos);
-    print  OUT draw($seq, $struct), "\n\n";
+    print  OUT mining::fix_hairpin(draw($seq, $struct), $seq), "\n\n";
 }
 
 close(OUT) || die "Unable to close file '$output' after writing: $!\n";

--- a/scripts/lib/mining.pm
+++ b/scripts/lib/mining.pm
@@ -110,8 +110,11 @@ sub _parse_mirbase_dat_block
     return if ($req_species && uc($species) ne uc($req_species));
 
     # second we want to obtain the accession
-    return unless ($$ref_lines =~ /^AC\s+(\S+);/m);
-    my $accession = $1;
+    my $accession = "";
+    if ($$ref_lines =~ /^AC\s+(\S+);/m)
+    {
+	$accession = $1;
+    }
 
     # get the FT blocks for a mircoRNA
     my @matures = ();

--- a/scripts/lib/mining.pm
+++ b/scripts/lib/mining.pm
@@ -450,4 +450,66 @@ sub export_mirbase_data
     close(FH) || die "Unable to close file '$file': $!\n";
 }
 
+sub fix_hairpin
+{
+    my ($structure, $sequence) = @_;
+
+    # split the structure into its lines
+    my @lines = split(/\n/, $structure);
+
+    # and each line into its characters
+    @lines = map { [split("", $_)] } (@lines);
+
+    # split the input sequence into its characters
+    my @seq = split("", $sequence);
+
+    my $width = int(@{$lines[0]});
+
+    # now go through the lines 1 and 2 and substitute each character
+    # found, with the next character from our input sequence and
+    # second test lines 4 and 5 for the same condition and use the
+    # last character from the sequence as substitution character
+    for(my $x=0; $x<$width; $x++)
+    {
+	# test if y=0 or y=1 contains the character
+	my $y;
+	if ($lines[0][$x] !~ /[-\s]/)
+	{
+	    $y = 0;
+	} elsif ($lines[1][$x] !~ /[-\s]/)
+	{
+	    $y = 1;
+	}
+
+	# set the next character from our input sequence
+	$lines[$y][$x] = shift @seq if (defined $y);
+
+	# test if y=3 or y=4 contains the character
+	$y=undef;
+	if ($lines[3][$x] !~ /[-\s]/)
+	{
+	    $y = 3;
+	} elsif ($lines[4][$x] !~ /[-\s]/)
+	{
+	    $y = 4;
+	}
+
+	# set the next character from our input sequence
+	$lines[$y][$x] = pop @seq if (defined $y)
+    }
+
+    # if sequence still contain a letter, it should be on line 3 at
+    # the very last position
+    if (@seq)
+    {
+	if ($lines[2][$width-1] !~ /[-\s]/)
+	{
+	    $lines[2][$width-1] = shift @seq;
+	}
+    }
+
+    # last join each line and all lines together
+    return join("\n", map { join("", @{$_}) } (@lines));
+}
+
 1;

--- a/t/mining-lib.t
+++ b/t/mining-lib.t
@@ -1,0 +1,41 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use FindBin;
+use lib "$FindBin::Bin/../scripts/lib";
+
+use mining;
+use RNA::HairpinFigure;
+
+my @testcases = (
+    {
+	sequence  => "UUCGCGAGUUCCGUGCUUCCUUACUUCCCAUAGUGCUUUAAACGUAUGGAAUGUAAAGAAGUAUGGAGCGAA",
+	structure => ".......((((((((((((.((((...(((((((.......)).)))))...)))).))))))))))))...",
+	expected  => "UUCGCGA            C    UUC     -  GC \n".
+                     "       GUUCCGUGCUUC UUAC   CCAUA GU  U\n".
+                     "       |||||||||||| ||||   ||||| ||  U\n".
+                     "       CGAGGUAUGAAG AAUG   GGUAU CA  U\n".
+                     "----AAG            A    UAA     G  AA ",
+	title     => "Wrong structure from RNA::HairpinFigure"
+    },
+    {
+	sequence  => "uaaacaguauacagaaagcCAUCAAAGCGGUGGUUGAUGUGuugcaaauuaugacuuucaUAUCACAGCCAGCUUUGAUGUGCugccuguugcacugu",
+	structure => "...(((((..((((..(((((((((((((((...(((((((..(((.....)).)...)))))))..))).))))))))).)))..))))...)))))",
+	expected  => "uaa     -au    aa   -         -   GGU       -uu -  a \n".
+                     "   acagu   acag  agc CAUCAAAGC GGU   UGAUGUG   g ca a\n".
+                     "   |||||   ||||  ||| ||||||||| |||   |||||||   | || u\n".
+                     "   uguca   uguc  uCG GUAGUUUCG CCG   ACUAUac   c gu u\n".
+                     "---     cgu    cg   U         A   -AC       uuu a  a ",
+	title     => "Correct structure from RNA::HairpinFigure"
+    },
+);
+
+foreach my $case (@testcases)
+{
+    my $got = mining::fix_hairpin(draw($case->{sequence}, $case->{structure}), $case->{sequence});
+    is($got, $case->{expected}, $case->{title});
+}
+
+done_testing();


### PR DESCRIPTION
Fixes #117, #131, #134, and #137 .

Changes proposed within this pull request
-    Copying pseudo mirBASE dat file `final_mirbase_pseudofile.dat` into output folder (Fixes [#131](https://github.com/microPIECE-team/microPIECE/issues/131))
-    Corrected `RNA::HairpinFigure` output (Fixes [#137](https://github.com/microPIECE-team/microPIECE/issues/137))
-   Fix the requirement of an accession inside mirBASE dat file (Fixes [#134](https://github.com/microPIECE-team/microPIECE/issues/134))
-    Avoiding error message while copying the out file for genomic location into base folder (Fixes [#117](https://github.com/microPIECE-team/microPIECE/issues/117))

Release tasks:
- [x] `microPIECE.pl`
- [x] `README.md`
- [x] `lib/microPIECE.pm`
- [x] `docker/Dockerfile`

@microPIECE-team/micropiece-team-admins
