### PR TITLE
Output filename is derived from minlength variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,8 @@ Please report any new issues ad [new Github-Issue](https://github.com/microPIECE
 ## Changelog
 - scheduled for next release
 
+    Dynamic naming of output files based on minlength variable in `run_CLIP_clip_mapper` (Fixes [#146](https://github.com/microPIECE-team/microPIECE/issues/146))
+
     Correct calculation of length of a bed feature and moving `scripts/CLIP_bedtool_discard_sizes.pl` into `lib/microPIECE.pm` (Fixes [#147](https://github.com/microPIECE-team/microPIECE/iss
 ues/147))
 

--- a/lib/microPIECE.pm
+++ b/lib/microPIECE.pm
@@ -1285,7 +1285,7 @@ sub run_CLIP_clip_mapper
 
     foreach my $file (@inputfiles)
     {
-	my $outputname = getcwd()."/".basename($file, ".bed")."_mapGFF_minLen0.bed";
+	my $outputname = sprintf("%s/%s_mapGFF_minLen%i.bed", getcwd(), basename($file, ".bed"), $minlength);
 	my @cmd = ($opt->{scriptdir}."CLIP_mapper.pl", $file, $opt->{annotationA}, $minlength);
 	run_cmd($L, \@cmd, undef, $outputname);
     }

--- a/lib/microPIECE.pm
+++ b/lib/microPIECE.pm
@@ -1223,7 +1223,7 @@ sub run_CLIP_process
     my $min = 22;
     my $max = 50;
 
-    my @inputfiles = glob("clip_merged_*of*BEDfilter_mapGFF_minLen0.bed");
+    my @inputfiles = glob("clip_merged_*of*BEDfilter_mapGFF_minLen*.bed");
 
     foreach my $file (@inputfiles)
     {

--- a/lib/microPIECE.pm
+++ b/lib/microPIECE.pm
@@ -3,7 +3,7 @@ package microPIECE;
 use strict;
 use warnings;
 
-use version 0.77; our $VERSION = version->declare("v1.4.1");
+use version 0.77; our $VERSION = version->declare("v1.4.2");
 
 use Log::Log4perl;
 use Data::Dumper;

--- a/microPIECE.pl
+++ b/microPIECE.pl
@@ -431,6 +431,8 @@ Please report any new issues ad L<new Github-Issue|https://github.com/microPIECE
 
 =item scheduled for next release
 
+Dynamic naming of output files based on minlength variable in C<run_CLIP_clip_mapper> (Fixes L<#146|https://github.com/microPIECE-team/microPIECE/issues/146>)
+
 Correct calculation of length of a bed feature and moving F<scripts/CLIP_bedtool_discard_sizes.pl> into F<lib/microPIECE.pm> (Fixes L<#147|https://github.com/microPIECE-team/microPIECE/issues/147>)
 
 =item L<v1.4.0|https://github.com/microPIECE-team/microPIECE/releases/tag/v1.4.0> (2018-03-31)


### PR DESCRIPTION
Fixes #146 .

Changes proposed within this pull request
- The output filename will be derived from the current value of the `$minlength` variable.

@microPIECE-team/micropiece-team-admins
