### PR TITLE
Commandline options to control length limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,12 @@ docker run -it --rm -v $PWD:/data micropiece/micropiece:v1.4.0 microPIECE.pl   \
     ignored. Default values are 22 for `--CLIPminProcessLength` and 50
     for `--CLIPmaxProcessLength`.
 
+- `--CLIPminlength`
+
+    An integer value specifying the minimal length of a CLIP peak to be
+    processed. Default value is 0, meaning no minimal length for CLIP
+    peaks.
+
 ### OUTPUT
 
 - pseudo mirBASE dat file: `final_mirbase_pseudofile.dat`

--- a/README.md
+++ b/README.md
@@ -179,6 +179,14 @@ docker run -it --rm -v $PWD:/data micropiece/micropiece:v1.4.0 microPIECE.pl   \
 
     Sets the `Piranah` bin size and has a default value of `20`.
 
+- `--CLIPminProcessLength` and `--CLIPmaxProcessLength`
+
+    Both are integer values and set the lower and upper limit for the
+    processed peak length. Peaks having a width below
+    `--CLIPminProcessLength` or above `--CLIPmaxProcessLength` are
+    ignored. Default values are 22 for `--CLIPminProcessLength` and 50
+    for `--CLIPmaxProcessLength`.
+
 ### OUTPUT
 
 - pseudo mirBASE dat file: `final_mirbase_pseudofile.dat`

--- a/README.md
+++ b/README.md
@@ -313,6 +313,8 @@ Please report any new issues ad [new Github-Issue](https://github.com/microPIECE
 ## Changelog
 - scheduled for next release
 
+    Add command line options `--CLIPminProcessLength`, `--CLIPmaxProcessLength`, and `--CLIPminlength` for length limits used in `run_CLIP_process` and `run_CLIP_clip_mapper` steps enabling processing of peaks with user defined widths (Fixes [#145](https://github.com/microPIECE-team/microPIECE/issues/145))
+
     Dynamic naming of output files based on minlength variable in `run_CLIP_clip_mapper` (Fixes [#146](https://github.com/microPIECE-team/microPIECE/issues/146))
 
     Correct calculation of length of a bed feature and moving `scripts/CLIP_bedtool_discard_sizes.pl` into `lib/microPIECE.pm` (Fixes [#147](https://github.com/microPIECE-team/microPIECE/iss

--- a/lib/microPIECE.pm
+++ b/lib/microPIECE.pm
@@ -1294,6 +1294,10 @@ sub run_CLIP_clip_mapper
     my $L = Log::Log4perl::get_logger();
 
     my $minlength = 0;
+    if (exists $opt->{CLIPminlength} && defined $opt->{CLIPminlength})
+    {
+	$minlength = $opt->{CLIPminlength};
+    }
 
     my @inputfiles = glob("clip_merged_*of*BEDfilter.bed");
 

--- a/lib/microPIECE.pm
+++ b/lib/microPIECE.pm
@@ -3,7 +3,7 @@ package microPIECE;
 use strict;
 use warnings;
 
-use version 0.77; our $VERSION = version->declare("v1.4.2");
+use version 0.77; our $VERSION = version->declare("v1.4.3");
 
 use Log::Log4perl;
 use Data::Dumper;

--- a/lib/microPIECE.pm
+++ b/lib/microPIECE.pm
@@ -1221,7 +1221,21 @@ sub run_CLIP_process
     my $L = Log::Log4perl::get_logger();
 
     my $min = 22;
+    if (exists $opt->{CLIPminProcessLength} && defined $opt->{CLIPminProcessLength})
+    {
+	$min = $opt->{CLIPminProcessLength};
+    }
     my $max = 50;
+    if (exists $opt->{CLIPmaxProcessLength} && defined $opt->{CLIPmaxProcessLength})
+    {
+	$max = $opt->{CLIPmaxProcessLength};
+    }
+
+    # check if min <= $max
+    if ($min > $max)
+    {
+	$L->logdie("Minimum length should be less than maximum length. You might specify other values using --CLIPmaxProcessLength or --CLIPminProcessLength parameter");
+    }
 
     my @inputfiles = glob("clip_merged_*of*BEDfilter_mapGFF_minLen*.bed");
 

--- a/microPIECE.pl
+++ b/microPIECE.pl
@@ -50,6 +50,9 @@ my $opt = {
     mirbasedir         => undef,
     tempdir            => undef,
     piranha_bin_size   => 20,
+
+    CLIPminProcessLength => undef,
+    CLIPmaxProcessLength => undef,
 };
 
 GetOptions(
@@ -75,6 +78,9 @@ GetOptions(
     'mirbasedir=s'         => \$opt->{mirbasedir},
     'tempdir=s'            => \$opt->{tempdir},
     'piranhabinsize=i'     => \$opt->{piranha_bin_size},
+
+    'CLIPmaxProcessLength=i' => \$opt->{CLIPmaxProcessLength},
+    'CLIPminProcessLength=i' => \$opt->{CLIPminProcessLength},
     ) || pod2usage(1);
 
 # split clip files if required
@@ -260,6 +266,14 @@ C<--out> parameter.
 =item C<--piranhabinsize>
 
 Sets the F<Piranha> bin size and has a default value of C<20>.
+
+=item C<--CLIPminProcessLength> and C<--CLIPmaxProcessLength>
+
+Both are integer values and set the lower and upper limit for the
+processed peak length. Peaks having a width below
+C<--CLIPminProcessLength> or above C<--CLIPmaxProcessLength> are
+ignored. Default values are 22 for C<--CLIPminProcessLength> and 50
+for C<--CLIPmaxProcessLength>.
 
 =back
 

--- a/microPIECE.pl
+++ b/microPIECE.pl
@@ -106,6 +106,12 @@ if($opt->{version}){
 	exit 0;
 }
 
+# CLIPmin/maxProcessLength
+if (defined $opt->{CLIPminProcessLength} && defined $opt->{CLIPmaxProcessLength} && $opt->{CLIPminProcessLength} > $opt->{CLIPmaxProcessLength})
+{
+    $L->logdie("Minimum length should be less than maximum length. You might specify other values using --CLIPmaxProcessLength or --CLIPminProcessLength parameter");
+}
+
 microPIECE::hello();
 STDOUT->flush();
 

--- a/microPIECE.pl
+++ b/microPIECE.pl
@@ -459,6 +459,8 @@ Please report any new issues ad L<new Github-Issue|https://github.com/microPIECE
 
 =item scheduled for next release
 
+Add command line options C<--CLIPminProcessLength>, C<--CLIPmaxProcessLength>, and C<--CLIPminlength> for length limits used in C<run_CLIP_process> and C<run_CLIP_clip_mapper> steps enabling processing of peaks with user defined widths (Fixes L<#145|https://github.com/microPIECE-team/microPIECE/issues/145>)
+
 Dynamic naming of output files based on minlength variable in C<run_CLIP_clip_mapper> (Fixes L<#146|https://github.com/microPIECE-team/microPIECE/issues/146>)
 
 Correct calculation of length of a bed feature and moving F<scripts/CLIP_bedtool_discard_sizes.pl> into F<lib/microPIECE.pm> (Fixes L<#147|https://github.com/microPIECE-team/microPIECE/issues/147>)

--- a/microPIECE.pl
+++ b/microPIECE.pl
@@ -283,6 +283,12 @@ C<--CLIPminProcessLength> or above C<--CLIPmaxProcessLength> are
 ignored. Default values are 22 for C<--CLIPminProcessLength> and 50
 for C<--CLIPmaxProcessLength>.
 
+=item C<--CLIPminlength>
+
+An integer value specifying the minimal length of a CLIP peak to be
+processed. Default value is 0, meaning no minimal length for CLIP
+peaks.
+
 =back
 
 =head1 OUTPUT

--- a/microPIECE.pl
+++ b/microPIECE.pl
@@ -53,6 +53,7 @@ my $opt = {
 
     CLIPminProcessLength => undef,
     CLIPmaxProcessLength => undef,
+    CLIPminlength        => undef,
 };
 
 GetOptions(
@@ -81,6 +82,7 @@ GetOptions(
 
     'CLIPmaxProcessLength=i' => \$opt->{CLIPmaxProcessLength},
     'CLIPminProcessLength=i' => \$opt->{CLIPminProcessLength},
+    'CLIPminlength=i'        => \$opt->{CLIPminlength},
     ) || pod2usage(1);
 
 # split clip files if required


### PR DESCRIPTION
Fixes #145 .

Changes proposed within this pull request
- Adds command line options `--CLIPminProcessLength`, `--CLIPmaxProcessLength`, and `--CLIPminlength` for length limits used in `run_CLIP_process` and `run_CLIP_clip_mapper` steps enabling processing of peaks with user defined widths

@microPIECE-team/micropiece-team-admins
